### PR TITLE
fix password leak in CBLChangeTracker thread name

### DIFF
--- a/src/main/java/com/couchbase/cblite/replicator/changetracker/CBLChangeTracker.java
+++ b/src/main/java/com/couchbase/cblite/replicator/changetracker/CBLChangeTracker.java
@@ -292,7 +292,9 @@ public class CBLChangeTracker implements Runnable {
 
     public boolean start() {
         this.error = null;
-        thread = new Thread(this, "ChangeTracker-" + databaseURL.toExternalForm());
+        String maskedRemoteWithoutCredentials = databaseURL.toExternalForm();
+        maskedRemoteWithoutCredentials = maskedRemoteWithoutCredentials.replaceAll("://.*:.*@", "://---:---@");
+        thread = new Thread(this, "ChangeTracker-" + maskedRemoteWithoutCredentials);
         thread.start();
         return true;
     }


### PR DESCRIPTION
Sanitized CBLChangeTracker's thread's name the same way log messages are sanitized. Thread names get sent out in Android crash reports, Crashlytics, etc.
