### PR TITLE
NPE when downloader encounters unknown content type

### DIFF
--- a/src/main/java/com/couchbase/cblite/support/CBLRemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/cblite/support/CBLRemoteMultipartDownloaderRequest.java
@@ -79,7 +79,8 @@ public class CBLRemoteMultipartDownloaderRequest extends CBLRemoteRequest {
                 Header contentTypeHeader = entity.getContentType();
                 InputStream inputStream = null;
 
-                if (contentTypeHeader.getValue().contains("multipart/related")) {
+                if (contentTypeHeader != null
+                        && contentTypeHeader.getValue().contains("multipart/related")) {
 
                     try {
                         CBLMultipartDocumentReader reader = new CBLMultipartDocumentReader(response, db);


### PR DESCRIPTION
Our production crash logs show occasional crashes due to a NullPointerException in CBLRemoteMultipartDownloaderRequest.java, line 82. It seems that `contentTypeHeader` is sometimes null. I haven't been able to reproduce it myself, but it seems reasonable enough to guard against this case here.
