### PR TITLE
Fixes for my two issues

### DIFF
--- a/src/main/java/com/couchbase/cblite/CBLAttachment.java
+++ b/src/main/java/com/couchbase/cblite/CBLAttachment.java
@@ -26,6 +26,7 @@ public class CBLAttachment {
     private InputStream contentStream;
     private String contentType;
     private Map<String, Object> metadata;
+    private boolean gzipped;
 
     public CBLAttachment() {
 
@@ -37,6 +38,7 @@ public class CBLAttachment {
         metadata = new HashMap<String, Object>();
         metadata.put("content_type", contentType);
         metadata.put("follows", true);
+        gzipped = false;
     }
 
     public InputStream getContentStream() {
@@ -55,7 +57,13 @@ public class CBLAttachment {
         this.contentType = contentType;
     }
 
+    public boolean getGZipped() {
+        return gzipped;
+    }
 
+    public void setGZipped(boolean gzipped) {
+        this.gzipped = gzipped;
+    }
 
 
 }

--- a/src/main/java/com/couchbase/cblite/CBLBlobStore.java
+++ b/src/main/java/com/couchbase/cblite/CBLBlobStore.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.zip.GZIPInputStream;
 
 import android.util.Log;
 
@@ -299,6 +301,22 @@ public class CBLBlobStore {
 
     public int deleteBlobs() {
         return deleteBlobsExceptWithKeys(new ArrayList<CBLBlobKey>());
+    }
+    
+    public boolean isGZipped(CBLBlobKey key) {
+        int magic = 0;
+        String path = pathForKey(key);
+        File file = new File(path);
+        if (file.canRead()) {
+            try {
+                RandomAccessFile raf = new RandomAccessFile(file, "r");
+                magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
+                raf.close();
+            } catch (Throwable e) {
+                e.printStackTrace(System.err);
+            }
+        }
+        return magic == GZIPInputStream.GZIP_MAGIC;
     }
 
     public File tempDir() {

--- a/src/main/java/com/couchbase/cblite/CBLDatabase.java
+++ b/src/main/java/com/couchbase/cblite/CBLDatabase.java
@@ -207,8 +207,28 @@ public class CBLDatabase extends Observable {
         if(attachmentsPath != null) {
             FileDirUtils.copyFolder(new File(attachmentsPath), attachmentsFile);
         }
+        replaceUUIDs();
         return true;
     }
+    
+    public boolean replaceUUIDs() {
+        String query = "UPDATE INFO SET value='"+CBLMisc.TDCreateUUID()+"' where key = 'privateUUID';";
+        try {
+            database.execSQL(query);
+        } catch (SQLException e) {
+            Log.e(CBLDatabase.TAG, "Error updating UUIDs", e);
+            return false;
+        }
+        query = "UPDATE INFO SET value='"+CBLMisc.TDCreateUUID()+"' where key = 'publicUUID';";
+        try {
+            database.execSQL(query);
+        } catch (SQLException e) {
+            Log.e(CBLDatabase.TAG, "Error updating UUIDs", e);
+            return false;
+        }
+        return true;
+    }
+
 
     public boolean initialize(String statements) {
         try {
@@ -1485,6 +1505,7 @@ public class CBLDatabase extends Observable {
                 CBLAttachment result = new CBLAttachment();
                 result.setContentStream(contentStream);
                 result.setContentType(cursor.getString(1));
+                result.setGZipped(attachments.isGZipped(key));
                 return result;
             }
 

--- a/src/main/java/com/couchbase/cblite/router/CBLRouter.java
+++ b/src/main/java/com/couchbase/cblite/router/CBLRouter.java
@@ -1238,7 +1238,7 @@ public class CBLRouter implements Observer {
 
     	String type = null;
     	CBLStatus status = new CBLStatus();
-    	String acceptEncoding = connection.getRequestProperty("Accept-Encoding");
+    	String acceptEncoding = connection.getRequestProperty("accept-encoding");
     	CBLAttachment contents = db.getAttachmentForSequence(rev.getSequence(), _attachmentName, status);
 
     	if (contents == null) {
@@ -1248,8 +1248,8 @@ public class CBLRouter implements Observer {
     	if (type != null) {
     		connection.getResHeader().add("Content-Type", type);
     	}
-    	if (acceptEncoding != null && acceptEncoding.equals("gzip")) {
-    		connection.getResHeader().add("Content-Encoding", acceptEncoding);
+    	if (acceptEncoding != null && acceptEncoding.contains("gzip") && contents.getGZipped()) {
+    		connection.getResHeader().add("Content-Encoding", "gzip");
     	}
 
         connection.setResponseInputStream(contents.getContentStream());


### PR DESCRIPTION
couchbase/couchbase-lite-android#108 and couchbase/couchbase-lite-android#94

Put a boolean on CBLAttachment to indicate whether it is gzipped or not, with a getter and a setter.
Added a way to test whether an attachment is gzipped.
Replace UUID's after a database copy.
Parse out content-encoding correctly. Support for 'gzip, deflate' values.
