### PR TITLE
Removed assertion on startKey and endKey because they also support non string keys

### DIFF
--- a/src/main/java/com/couchbase/cblite/CBLView.java
+++ b/src/main/java/com/couchbase/cblite/CBLView.java
@@ -462,7 +462,6 @@ public class CBLView {
         }
 
         if (minKey != null) {
-            assert (minKey instanceof String);
             if (inclusiveMin) {
                 sql += " AND key >= ?";
             } else {
@@ -473,7 +472,6 @@ public class CBLView {
         }
 
         if (maxKey != null) {
-            assert (maxKey instanceof String);
             if (inclusiveMax) {
                 sql += " AND key <= ?";
             } else {


### PR DESCRIPTION
The method toJSONString is called on the start or end key before they are added to the argument list. And the key column uses the JSON collation. Therefore the start and and key can be any object that is supported by toJSONString(). You probably don't want to use (map objects aka JSON objects) because I don't think that the fields of the object are sorted before they are converted to JSON. But array keys isn't a problem (just remember to add an empty arraylist at the end of the list for the endKey).
