### PR TITLE
Added a API to pass SSLSocketFactory

### DIFF
--- a/src/main/java/com/couchbase/cblite/support/CBLHttpClientFactory.java
+++ b/src/main/java/com/couchbase/cblite/support/CBLHttpClientFactory.java
@@ -21,6 +21,19 @@ public enum CBLHttpClientFactory implements HttpClientFactory {
 
     private CookieStore cookieStore;
 
+    private SSLSocketFactory sslSocketFactory;
+
+    /**
+     * @param sslSocketFactoryFromUser This is to open up the system for end user to inject the sslSocket factories with their
+     *                                 custom KeyStore
+     */
+    public void setSSLSocketFactory(SSLSocketFactory sslSocketFactoryFromUser) {
+        if (sslSocketFactory != null) {
+            throw new RuntimeException("SSLSocketFactory already set");
+        }
+        sslSocketFactory = sslSocketFactoryFromUser;
+    }
+
     @Override
     public HttpClient getHttpClient() {
 
@@ -32,7 +45,7 @@ public enum CBLHttpClientFactory implements HttpClientFactory {
         SchemeRegistry schemeRegistry = new SchemeRegistry();
         schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
         final SSLSocketFactory sslSocketFactory = SSLSocketFactory.getSocketFactory();
-        schemeRegistry.register(new Scheme("https", sslSocketFactory, 443));
+        schemeRegistry.register(new Scheme("https", this.sslSocketFactory == null ? sslSocketFactory : this.sslSocketFactory, 443));
         ClientConnectionManager cm = new ThreadSafeClientConnManager(params, schemeRegistry);
 
         DefaultHttpClient client = new DefaultHttpClient(cm, params);
@@ -56,8 +69,6 @@ public enum CBLHttpClientFactory implements HttpClientFactory {
             }
         }
     }
-
-
 
 
 }


### PR DESCRIPTION
This feature will ensure that the user can pass the SSLSocketFactory with the custom KeyStores.
An example  where the `ca.pem` file is in assets folder.

I have an example implementation on how to load  a certificate  and then assign it to `CBLHttpClientFactory`

```
public MySSLSocketFactory(KeyStore truststore) throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException {
    super(truststore);

    TrustManager tm = new X509TrustManager() {
        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
        }

        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
        }

        public X509Certificate[] getAcceptedIssuers() {
            return null;
        }
    };

    sslContext.init(null, new TrustManager[] { tm }, null);
}


private void initializeSecurity() throws IOException, CertificateException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, InterruptedException, UnrecoverableKeyException {
    AssetManager am = getAssets();
    InputStream is = am.open("ca.pem");
    // Load CAs from an InputStream
    CertificateFactory cf = CertificateFactory.getInstance("X.509");
    InputStream caInput = new BufferedInputStream(is);
    Certificate ca;
    try {
        ca = cf.generateCertificate(caInput);
    } finally {
        caInput.close();
    }
    // Create a KeyStore containing our trusted CAs
    String keyStoreType = KeyStore.getDefaultType();
    keyStore = KeyStore.getInstance(keyStoreType);
    keyStore.load(null, null);
    keyStore.setCertificateEntry("ca", ca);
    SSLSocketFactory sf = new MySSLSocketFactory(keyStore);
    CBLHttpClientFactory.INSTANCE.setSSLSocketFactory(sf);
}
```

Simply call `CBLHttpClientFactory.INSTANCE.setSSLSocketFactory(sf);`

This feature is tested on my app.
Test case1: Load the custom ssl factory with verified certificates. The replication to an ssl end point should pass
Test case2: Call the `CBLHttpClientFactory.INSTANCE.setSSLSocketFactory(sf);` and it should fail
Test case3: Pass null in `CBLHttpClientFactory.INSTANCE.setSSLSocketFactory(null)` and the library picks up the default SSLSocketFactory and proceeds
