### PR TITLE
fix null pointer exception in CBLChangeTracker.run()

### DIFF
--- a/src/main/java/com/couchbase/cblite/replicator/changetracker/CBLChangeTracker.java
+++ b/src/main/java/com/couchbase/cblite/replicator/changetracker/CBLChangeTracker.java
@@ -147,8 +147,16 @@ public class CBLChangeTracker implements Runnable {
 
     @Override
     public void run() {
+        // depending on thread scheduling, run() can execute after CBLPuller.stop(), which sets
+        // client to null. In that case, we shouldn't run.
+        CBLChangeTrackerClient clientHandle = client;
+        if (clientHandle == null) {
+            Log.w(CBLDatabase.TAG, "cancelling CBLChangeTracker run due to null client");
+            return;
+        }
+
         running = true;
-        HttpClient httpClient = client.getHttpClient();
+        HttpClient httpClient = clientHandle.getHttpClient();
         CBLChangeTrackerBackoff backoff = new CBLChangeTrackerBackoff();
 
         while (running) {


### PR DESCRIPTION
Production logs frequently report a NullPointerException crash in CBLChangeTracker.run() L151, where  `client` is null.

This is possible in this sequence of events:

(1) Client calls CBLPuller.start(). CBLPuller goes about its startup sequence. In `beginReplicating`, a new CBLChangeTracker is initialized and started, scheduling CBLChangeTracker.run() on a thread.

(2) Client calls CBLPuller.stop(). In that method, the changeTracker's `client` is set to null.

(3) Now, due to the mysteries of multithreading, the thread on which CBLChangeTracker.run() is called actually runs. Since `client` was set to null in (2), the thing blows up.

As of (1), CBLPuller.isRunning() is `true`, so stopping the puller as in (2) ought to be a valid state transition.

This commit sidesteps the multithreading issue by confirming that CBLChangeTracker.run() has a local, non-null handle on `client` before continuing, and assumes that a null client implies the sequence of events above (`stop` has been called, so we should simply cancel the call to `run`).

(fixes couchbase/couchbase-lite-android#109)
