### PR TITLE
fix remote authentication when username/password have special characters

### DIFF
--- a/src/main/java/com/couchbase/cblite/replicator/changetracker/CBLChangeTracker.java
+++ b/src/main/java/com/couchbase/cblite/replicator/changetracker/CBLChangeTracker.java
@@ -36,6 +36,7 @@ import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
 
+import android.net.Uri;
 import android.util.Log;
 
 import com.couchbase.cblite.CBLDatabase;
@@ -162,7 +163,8 @@ public class CBLChangeTracker implements Runnable {
                 Log.v(CBLDatabase.TAG, "url.getUserInfo(): " + url.getUserInfo());
                 if (url.getUserInfo().contains(":") && !url.getUserInfo().trim().equals(":")) {
                     String[] userInfoSplit = url.getUserInfo().split(":");
-                    final Credentials creds = new UsernamePasswordCredentials(userInfoSplit[0], userInfoSplit[1]);
+                    final Credentials creds = new UsernamePasswordCredentials(
+                            Uri.decode(userInfoSplit[0]), Uri.decode(userInfoSplit[1]));
                     if (httpClient instanceof DefaultHttpClient) {
                         DefaultHttpClient dhc = (DefaultHttpClient) httpClient;
 

--- a/src/main/java/com/couchbase/cblite/support/CBLRemoteRequest.java
+++ b/src/main/java/com/couchbase/cblite/support/CBLRemoteRequest.java
@@ -39,6 +39,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 
+import android.net.Uri;
 import android.os.Handler;
 import android.util.Log;
 
@@ -165,7 +166,7 @@ public class CBLRemoteRequest implements Runnable {
             if (url.getUserInfo().contains(":") && !url.getUserInfo().trim().equals(":")) {
                 String[] userInfoSplit = url.getUserInfo().split(":");
                 final Credentials creds = new UsernamePasswordCredentials(
-                        userInfoSplit[0], userInfoSplit[1]);
+                        Uri.decode(userInfoSplit[0]), Uri.decode(userInfoSplit[1]));
                 if (httpClient instanceof DefaultHttpClient) {
                     DefaultHttpClient dhc = (DefaultHttpClient) httpClient;
 


### PR DESCRIPTION
CBLChangeTracker and CBLRemoteRequest read credentials out of a URL object, which will return them in url-encoded form. They have to be url-decoded before use, or authentication with the remote doesn't work.

(fixes couchbase/couchbase-lite-android#26)
