### PR TITLE
use newer, thread-safe BasicCookieStore

### DIFF
--- a/src/main/java/com/couchbase/cblite/support/CBLHttpClientFactory.java
+++ b/src/main/java/com/couchbase/cblite/support/CBLHttpClientFactory.java
@@ -8,7 +8,7 @@ import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.cookie.Cookie;
-import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.trunk.BasicCookieStore;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;

--- a/src/main/java/com/couchbase/cblite/support/CBLRemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/cblite/support/CBLRemoteMultipartDownloaderRequest.java
@@ -15,7 +15,7 @@ import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.cookie.Cookie;
-import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.trunk.BasicCookieStore;
 import org.apache.http.impl.client.DefaultHttpClient;
 
 import java.io.IOException;

--- a/src/main/java/com/couchbase/cblite/support/CBLRemoteRequest.java
+++ b/src/main/java/com/couchbase/cblite/support/CBLRemoteRequest.java
@@ -33,7 +33,7 @@ import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.trunk.BasicCookieStore;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;

--- a/src/main/java/org/apache/http/annotation/GuardedBy.java
+++ b/src/main/java/org/apache/http/annotation/GuardedBy.java
@@ -1,0 +1,76 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The field or method to which this annotation is applied can only be accessed
+ * when holding a particular lock, which may be a built-in (synchronization) lock,
+ * or may be an explicit java.util.concurrent.Lock.
+ *
+ * The argument determines which lock guards the annotated field or method:
+ * <ul>
+ * <li>
+ * <code>this</code> : The intrinsic lock of the object in whose class the field is defined.
+ * </li>
+ * <li>
+ * <code>class-name.this</code> : For inner classes, it may be necessary to disambiguate 'this';
+ * the <em>class-name.this</em> designation allows you to specify which 'this' reference is intended
+ * </li>
+ * <li>
+ * <code>itself</code> : For reference fields only; the object to which the field refers.
+ * </li>
+ * <li>
+ * <code>field-name</code> : The lock object is referenced by the (instance or static) field
+ * specified by <em>field-name</em>.
+ * </li>
+ * <li>
+ * <code>class-name.field-name</code> : The lock object is reference by the static field specified
+ * by <em>class-name.field-name</em>.
+ * </li>
+ * <li>
+ * <code>method-name()</code> : The lock object is returned by calling the named nil-ary method.
+ * </li>
+ * <li>
+ * <code>class-name.class</code> : The Class object for the specified class should be used as the lock object.
+ * </li>
+ * <p>
+ * Based on code developed by Brian Goetz and Tim Peierls and concepts
+ * published in 'Java Concurrency in Practice' by Brian Goetz, Tim Peierls,
+ * Joshua Bloch, Joseph Bowbeer, David Holmes and Doug Lea.
+ */
+@Documented
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.CLASS) // The original version used RUNTIME
+public @interface GuardedBy {
+    String value();
+}

--- a/src/main/java/org/apache/http/annotation/ThreadSafe.java
+++ b/src/main/java/org/apache/http/annotation/ThreadSafe.java
@@ -1,0 +1,51 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The class to which this annotation is applied is thread-safe.  This means that
+ * no sequences of accesses (reads and writes to public fields, calls to public methods)
+ * may put the object into an invalid state, regardless of the interleaving of those actions
+ * by the runtime, and without requiring any additional synchronization or coordination on the
+ * part of the caller.
+ * @see NotThreadSafe
+ * <p>
+ * Based on code developed by Brian Goetz and Tim Peierls and concepts
+ * published in 'Java Concurrency in Practice' by Brian Goetz, Tim Peierls,
+ * Joshua Bloch, Joseph Bowbeer, David Holmes and Doug Lea.
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS) // The original version used RUNTIME
+public @interface ThreadSafe {
+}

--- a/src/main/java/org/apache/http/impl/client/trunk/BasicCookieStore.java
+++ b/src/main/java/org/apache/http/impl/client/trunk/BasicCookieStore.java
@@ -1,0 +1,144 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.impl.client.trunk;
+
+import org.apache.http.annotation.GuardedBy;
+import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.cookie.CookieIdentityComparator;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+
+/**
+ * Default implementation of {@link CookieStore}
+ *
+ *
+ * @since 4.0
+ */
+@ThreadSafe
+public class BasicCookieStore implements CookieStore, Serializable {
+
+    private static final long serialVersionUID = -7581093305228232025L;
+
+    @GuardedBy("this")
+    private final TreeSet<Cookie> cookies;
+
+    public BasicCookieStore() {
+        super();
+        this.cookies = new TreeSet<Cookie>(new CookieIdentityComparator());
+    }
+
+    /**
+     * Adds an {@link Cookie HTTP cookie}, replacing any existing equivalent cookies.
+     * If the given cookie has already expired it will not be added, but existing
+     * values will still be removed.
+     *
+     * @param cookie the {@link Cookie cookie} to be added
+     *
+     * @see #addCookies(Cookie[])
+     *
+     */
+    public synchronized void addCookie(final Cookie cookie) {
+        if (cookie != null) {
+            // first remove any old cookie that is equivalent
+            cookies.remove(cookie);
+            if (!cookie.isExpired(new Date())) {
+                cookies.add(cookie);
+            }
+        }
+    }
+
+    /**
+     * Adds an array of {@link Cookie HTTP cookies}. Cookies are added individually and
+     * in the given array order. If any of the given cookies has already expired it will
+     * not be added, but existing values will still be removed.
+     *
+     * @param cookies the {@link Cookie cookies} to be added
+     *
+     * @see #addCookie(Cookie)
+     *
+     */
+    public synchronized void addCookies(final Cookie[] cookies) {
+        if (cookies != null) {
+            for (final Cookie cooky : cookies) {
+                this.addCookie(cooky);
+            }
+        }
+    }
+
+    /**
+     * Returns an immutable array of {@link Cookie cookies} that this HTTP
+     * state currently contains.
+     *
+     * @return an array of {@link Cookie cookies}.
+     */
+    public synchronized List<Cookie> getCookies() {
+        //create defensive copy so it won't be concurrently modified
+        return new ArrayList<Cookie>(cookies);
+    }
+
+    /**
+     * Removes all of {@link Cookie cookies} in this HTTP state
+     * that have expired by the specified {@link java.util.Date date}.
+     *
+     * @return true if any cookies were purged.
+     *
+     * @see Cookie#isExpired(Date)
+     */
+    public synchronized boolean clearExpired(final Date date) {
+        if (date == null) {
+            return false;
+        }
+        boolean removed = false;
+        for (final Iterator<Cookie> it = cookies.iterator(); it.hasNext();) {
+            if (it.next().isExpired(date)) {
+                it.remove();
+                removed = true;
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Clears all cookies.
+     */
+    public synchronized void clear() {
+        cookies.clear();
+    }
+
+    @Override
+    public synchronized String toString() {
+        return cookies.toString();
+    }
+
+}


### PR DESCRIPTION
In production logs, we would frequently get ConcurrentModificationException in CBLHttpClientFactory.addCookies. Tracing the code for a potential concurrent modification was fruitless.

Updating to a more recent verion of Apache's BasicCookieStore that is newer than what Android provides and has been rewritten with better concurrency support stopped the issue from occurring.

(fixes couchbase/couchbase-lite-android-core#4)

(**Note:** having to inline the code & change the namespace on it is kind of unfortunate, but I'm not sure what else to do in this case. This was our second-highest incidence crash after couchbase/couchbase-lite-android#109 until we rolled out this change. Happy to help with improvements to the patch or another direction.)
