### PR TITLE
Properly report error when view query fails

### DIFF
--- a/src/main/java/com/couchbase/cblite/router/CBLRouter.java
+++ b/src/main/java/com/couchbase/cblite/router/CBLRouter.java
@@ -1476,7 +1476,7 @@ public class CBLRouter implements Observer {
 
         List<Map<String,Object>> rows = view.queryWithOptions(options, status);
         if(rows == null) {
-            return status;
+            return new CBLStatus(CBLStatus.INTERNAL_SERVER_ERROR);
         }
 
         Map<String,Object> responseBody = new HashMap<String,Object>();


### PR DESCRIPTION
CBLRouter.queryDesignDoc falsely reports success when CBLView.queryWithOptions hits a SQLException and returns null. In that case, queryWithOptions returns the current value of 'status', which is always a successful one (see [CBLRouter:L1463](https://github.com/couchbase/couchbase-lite-android-core/blob/master/src/main/java/com/couchbase/cblite/router/CBLRouter.java#L1463)), resulting in a malformed response.

This manifests itself in error logs like:

```
[org.ektorp.ViewResult:L30] IllegalArgumentException: result must contain 'rows' field of array type
```

as Ektorp tries to make assertions about the incorrectly-successful result.

This patch changes queryDesignDoc to return an INTERNAL_SERVER_ERROR status in this case.
