### PR TITLE
Set up another boolean (stopping) to ensure that running is not set as f...

### DIFF
--- a/src/main/java/com/couchbase/cblite/replicator/CBLReplicator.java
+++ b/src/main/java/com/couchbase/cblite/replicator/CBLReplicator.java
@@ -300,6 +300,7 @@ public abstract class CBLReplicator extends Observable {
 
     public void stop() {
         if (!running) {
+            Log.d(CBLDatabase.TAG, toString() + " Not running...");
             return;
         }
         Log.d(CBLDatabase.TAG, toString() + " STOPPING...");
@@ -316,9 +317,6 @@ public abstract class CBLReplicator extends Observable {
         this.changesProcessed = this.changesTotal = 0;
         Log.d(CBLDatabase.TAG, this + " stopped() calling saveLastSequence()");
         saveLastSequence();
-        setChanged();
-
-        batcher = null;
     }
 
     protected void login() {
@@ -642,6 +640,8 @@ public abstract class CBLReplicator extends Observable {
     public void setStopped() {
         if (stopping) {
             Log.d(CBLDatabase.TAG, this + " stopping was set and checkpoint was saved. Setting running as false");    
+            setChanged();
+            batcher = null;
             stopping = false;
             running = false;
             notifyObservers();


### PR DESCRIPTION
...alse until the remote checkpoint is saved to ensure there are no stale values as per issue 108 on couchbase-lite-android.
