### PR TITLE
Fix NullPointerException in Document.getRevision()

### DIFF
--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -203,7 +203,7 @@ public class Document {
      */
     @InterfaceAudience.Public
     public SavedRevision getRevision(String id) {
-        if (id.equals(currentRevision.getId())) {
+        if (currentRevision != null && id.equals(currentRevision.getId())) {
             return currentRevision;
         }
         EnumSet<Database.TDContentOptions> contentOptions = EnumSet.noneOf(Database.TDContentOptions.class);


### PR DESCRIPTION
If you try to get a specific revision using Document.getRevision, but the current revision has never been retrieved (and so `currentRevision` is null), a NullPointerException is thrown.
