### PR TITLE
Incorrect/stale data in Database change handlers

### DIFF
--- a/src/instrumentTest/java/com/couchbase/lite/RevTreeTest.java
+++ b/src/instrumentTest/java/com/couchbase/lite/RevTreeTest.java
@@ -190,9 +190,9 @@ public class RevTreeTest extends LiteTestCase {
                 assertFalse(change.isConflict()); // fails
 
                 Document doc = database.getDocument(change.getDocumentId());
-                assertEquals(rev3.getRevId(), doc.getCurrentRevisionId()); // fails
+                assertEquals(rev3.getRevId(), doc.getCurrentRevisionId());
                 try {
-                    assertEquals(3, doc.getRevisionHistory().size()); // fails
+                    assertEquals(3, doc.getRevisionHistory().size());
                 } catch (CouchbaseLiteException ex) {
                     fail("CouchbaseLiteException in change listener: " + ex.toString());
                 }
@@ -225,7 +225,7 @@ public class RevTreeTest extends LiteTestCase {
                 assertTrue(change.isConflict());
 
                 Document doc = database.getDocument(change.getDocumentId());
-                assertEquals(conflictRev.getRevId(), doc.getCurrentRevisionId()); //fails
+                assertEquals(conflictRev.getRevId(), doc.getCurrentRevisionId());
                 try {
                     assertEquals(2, doc.getConflictingRevisions().size());
                     assertEquals(3, doc.getRevisionHistory().size());

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -2636,12 +2636,6 @@ public class Database {
         changes.add(change);
         ChangeEvent changeEvent = new ChangeEvent(this, isExternalFixMe, changes);
 
-        synchronized (changeListeners) {
-            for (ChangeListener changeListener : changeListeners) {
-                changeListener.changed(changeEvent);
-            }
-        }
-
         // TODO: this is expensive, it should be using a WeakHashMap
         // TODO: instead of loading from the DB.  iOS code below.
         /*
@@ -2655,6 +2649,12 @@ public class Database {
          */
         Document document = getDocument(change.getDocumentId());
         document.revisionAdded(change);
+
+        synchronized (changeListeners) {
+            for (ChangeListener changeListener : changeListeners) {
+                changeListener.changed(changeEvent);
+            }
+        }
 
     }
 


### PR DESCRIPTION
This pull request has a test that, I think, demonstrates two bugs, and fixes one of them.

In the first commit, I added a test that simulates some updates via replication, and then makes assertions at each step about the ChangeEvent and what the public API can see at that point. The failed assertions (marked with comments in the test) revealed two main issues:
- The current revision ID and revision history are stale
- The DocumentChange's `isConflict()` is always true

I encountered both of these while debugging something else yesterday, which motivated the test.

The first issue is fixed, I believe, in the second commit. The change listeners were getting called before the cached document's revision history was updated. Flipping those two actions fixed most of the assertion failures.

Now the only failures are the wrong isConflict flags. The bug is in [this section](https://github.com/couchbase/couchbase-lite-android-core/blob/master/src/main/java/com/couchbase/lite/Database.java#L3102-L3122). If you trace the algorithm you'll see that it sets inConflict if `revId` and `localParentRevId` don't match, but they will _never_ match when that check is made (because, in that side of the branch, localParentRevId is never updated but revId is).

I haven't tried to tackle that one yet, so it's still broken, but I hope all this helps anyway even with the dangling broken test. All the other tests still pass on my end after making the change.
