### PR TITLE
Remove misleading "failed to rebuild view" logs

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -382,6 +382,7 @@ public class View {
                 String msg = String.format("lastSequence (%d) == dbMaxSequence (%d), nothing to do",
                         lastSequence, dbMaxSequence);
                 Log.d(Database.TAG, msg);
+                result.setCode(Status.OK);
                 return;
             }
 


### PR DESCRIPTION
Here's a trivial one, but hopefully it saves someone a bit of debugging down the line :smiley: 

Log messages like

```
W/Database: Failed to rebuild view Event/all: 500
```

are being printed every time a view is checked for re-indexing but is already up to date. It looks like something's wrong, but it's a normal state.

Setting the result to Status.OK suppresses these logs in the finally block. The actual result (that reindexing was unnecessary) is still printed at Debug level.
