### PR TITLE
Always close response stream in ChangeTracker

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -251,42 +251,48 @@ public class ChangeTracker implements Runnable {
                 HttpEntity entity = response.getEntity();
                 InputStream input = null;
                 if (entity != null) {
-
-                    input = entity.getContent();
-                    if (mode == ChangeTrackerMode.LongPoll) {
-                        Map<String, Object> fullBody = Manager.getObjectMapper().readValue(input, Map.class);
-                        boolean responseOK = receivedPollResponse(fullBody);
-                        if (mode == ChangeTrackerMode.LongPoll && responseOK) {
-                            Log.v(Database.TAG, "Starting new longpoll");
-                            backoff.resetBackoff();
-                            continue;
+                    try {
+                        input = entity.getContent();
+                        if (mode == ChangeTrackerMode.LongPoll) {
+                            Map<String, Object> fullBody = Manager.getObjectMapper().readValue(input, Map.class);
+                            boolean responseOK = receivedPollResponse(fullBody);
+                            if (mode == ChangeTrackerMode.LongPoll && responseOK) {
+                                Log.v(Database.TAG, "Starting new longpoll");
+                                backoff.resetBackoff();
+                                continue;
+                            } else {
+                                Log.w(Database.TAG, "Change tracker calling stop");
+                                stop();
+                            }
                         } else {
-                            Log.w(Database.TAG, "Change tracker calling stop");
-                            stop();
-                        }
-                    } else {
 
-                        JsonFactory jsonFactory = Manager.getObjectMapper().getJsonFactory();
-                        JsonParser jp = jsonFactory.createJsonParser(input);
+                            JsonFactory jsonFactory = Manager.getObjectMapper().getJsonFactory();
+                            JsonParser jp = jsonFactory.createJsonParser(input);
 
-                        while (jp.nextToken() != JsonToken.START_ARRAY) {
-                            // ignore these tokens
-                        }
-
-                        while (jp.nextToken() == JsonToken.START_OBJECT) {
-                            Map<String, Object> change = (Map) Manager.getObjectMapper().readValue(jp, Map.class);
-                            if (!receivedChange(change)) {
-                                Log.w(Database.TAG, String.format("Received unparseable change line from server: %s", change));
+                            while (jp.nextToken() != JsonToken.START_ARRAY) {
+                                // ignore these tokens
                             }
 
+                            while (jp.nextToken() == JsonToken.START_OBJECT) {
+                                Map<String, Object> change = (Map) Manager.getObjectMapper().readValue(jp, Map.class);
+                                if (!receivedChange(change)) {
+                                    Log.w(Database.TAG, String.format("Received unparseable change line from server: %s", change));
+                                }
+
+                            }
+
+                            stop();
+                            break;
+
                         }
 
-                        stop();
-                        break;
-
+                        backoff.resetBackoff();
+                    } finally {
+                        try {
+                            entity.consumeContent();
+                        } catch (IOException ex) {
+                        }
                     }
-
-                    backoff.resetBackoff();
 
                 }
             } catch (Exception e) {


### PR DESCRIPTION
In the ChangeTracker's run method, the response stream is sometimes left unclosed.

When ChangeTrackerMode is LongPoll, the stream is closed after it has been read with ObjectMapper.readValue(). But, in the OneShot case, the stream is never closed, since the JsonParser never reaches the end of the stream.

It might be possible for the LongPoll case to leak too if an error is thrown, but I'm not sure. To be safe, I've wrapped both cases in a try/finally block that ensures the stream is always closed.

Found while investigating couchbase/couchbase-lite-android#176. Might be a contributing cause of those thread leaks.
