### PR TITLE
Fixed an issue where existing attachments are discarded on saving.

### DIFF
--- a/src/main/java/com/couchbase/lite/Attachment.java
+++ b/src/main/java/com/couchbase/lite/Attachment.java
@@ -201,6 +201,9 @@ public class Attachment {
             else if (value instanceof AttachmentInternal) {
                 throw new IllegalArgumentException("AttachmentInternal objects not expected here.  Could indicate a bug");
             }
+            else {
+                updatedAttachments.put(name, value);
+            }
         }
         return updatedAttachments;
     }


### PR DESCRIPTION
Proposed fix for #70.
Simply copy existing non-CBLite Attachments.
