### PR TITLE
Log View.getLastSequenceIndexed() exception details

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -143,7 +143,7 @@ public class View {
                 result = cursor.getLong(0);
             }
         } catch (Exception e) {
-            Log.e(Database.TAG, "Error getting last sequence indexed");
+            Log.e(Database.TAG, "Error getting last sequence indexed", e);
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
View.getLastSequenceIndexed() reports errors, but doesn't print the actual exception.

Helpful for cases like [this recent mailing list thread](https://groups.google.com/forum/#!topic/mobile-couchbase/n2y9LSCk-ZU).
