### PR TITLE
Allow for query settings chaining

### DIFF
--- a/src/main/java/com/couchbase/lite/Query.java
+++ b/src/main/java/com/couchbase/lite/Query.java
@@ -195,10 +195,10 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setLimit(int limit) {
+    public Query setLimit(int limit) {
         this.limit = limit;
+        return this;
     }
-
 
     @InterfaceAudience.Public
     public int getSkip() {
@@ -206,8 +206,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setSkip(int skip) {
+    public Query setSkip(int skip) {
         this.skip = skip;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -216,8 +217,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setDescending(boolean descending) {
+    public Query setDescending(boolean descending) {
         this.descending = descending;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -226,8 +228,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setStartKey(Object startKey) {
+    public Query setStartKey(Object startKey) {
         this.startKey = startKey;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -236,8 +239,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setEndKey(Object endKey) {
+    public Query setEndKey(Object endKey) {
         this.endKey = endKey;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -246,8 +250,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setStartKeyDocId(String startKeyDocId) {
+    public Query setStartKeyDocId(String startKeyDocId) {
         this.startKeyDocId = startKeyDocId;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -256,8 +261,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setEndKeyDocId(String endKeyDocId) {
+    public Query setEndKeyDocId(String endKeyDocId) {
         this.endKeyDocId = endKeyDocId;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -266,8 +272,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setIndexUpdateMode(IndexUpdateMode indexUpdateMode) {
+    public Query setIndexUpdateMode(IndexUpdateMode indexUpdateMode) {
         this.indexUpdateMode = indexUpdateMode;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -276,8 +283,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setAllDocsMode(AllDocsMode allDocsMode) {
+    public Query setAllDocsMode(AllDocsMode allDocsMode) {
         this.allDocsMode = allDocsMode;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -286,8 +294,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setKeys(List<Object> keys) {
+    public Query setKeys(List<Object> keys) {
         this.keys = keys;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -296,8 +305,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setMapOnly(boolean mapOnly) {
+    public Query setMapOnly(boolean mapOnly) {
         this.mapOnly = mapOnly;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -306,8 +316,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setGroupLevel(int groupLevel) {
+    public Query setGroupLevel(int groupLevel) {
         this.groupLevel = groupLevel;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -316,8 +327,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setPrefetch(boolean prefetch) {
+    public Query setPrefetch(boolean prefetch) {
         this.prefetch = prefetch;
+        return this;
     }
 
     @InterfaceAudience.Public
@@ -326,8 +338,9 @@ public class Query {
     }
 
     @InterfaceAudience.Public
-    public void setIncludeDeleted(boolean includeDeletedParam) {
+    public Query setIncludeDeleted(boolean includeDeletedParam) {
         allDocsMode = (includeDeletedParam == true) ? AllDocsMode.INCLUDE_DELETED : AllDocsMode.ALL_DOCS;
+        return this;
     }
 
     /**
@@ -401,7 +414,6 @@ public class Query {
                 }
             }
         });
-
     }
 
     /**
@@ -441,8 +453,4 @@ public class Query {
             view.delete();
         }
     }
-
-
-
-
 }


### PR DESCRIPTION
This change makes it easier for developers to set the options on
a query. For example,

``` java
Query query = view.createQuery().setLimit(10).setDescending(false);
```
