### PR TITLE
Rename variable to avoid AS complaining about a template variable

### DIFF
--- a/src/main/java/com/couchbase/lite/Reducer.java
+++ b/src/main/java/com/couchbase/lite/Reducer.java
@@ -12,9 +12,9 @@ public interface Reducer {
      *
      * @param keys An array of keys to be reduced (or null if this is a rereduce).
      * @param values A parallel array of values to be reduced, corresponding 1::1 with the keys.
-     * @param rereduce true if the input values are the results of previous reductions.
+     * @param reReduce true if the input values are the results of previous reductions.
      * @return The reduced value; almost always a scalar or small fixed-size object.
      */
-    Object reduce(List<Object> keys, List<Object> values, boolean rereduce);
+    Object reduce(List<Object> keys, List<Object> values, boolean reReduce);
 
 }


### PR DESCRIPTION
Makes the suggested variable in Android Studio not get marked as
being spelled incorrectly.

![image](https://f.cloud.github.com/assets/1709517/2490063/841b5092-b18c-11e3-9aad-d9b500612060.png)
