### PR TITLE
(#122) Make location return a relative URL

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -553,7 +553,7 @@ public class Router implements Database.ChangeListener {
     /*************************************************************************************************/
 
     public void setResponseLocation(URL url) {
-        String location = url.toExternalForm();
+        String location = url.getPath();
         String query = url.getQuery();
         if(query != null) {
             int startOfQuery = location.indexOf(query);


### PR DESCRIPTION
Issue #122

This is useful because otherwise we return a cblite:... URL that nobody
will know how to process (and anyway isn't properly formed since it doesn't
have an authority). By instead returning a relative URL we let the receiver
get a legal path that they can use however they got here in the first
place. This is particularly useful with Listener since we support
multiple protocols and none of them are visible in Router. But the rules
for relative URLs are the same everywhere so by returning a relative
URL we create a useful value regardless of how we got here.
