### PR TITLE
delete() database should remove all files/folder that were created

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -33,13 +33,11 @@ import com.couchbase.lite.support.Base64;
 import com.couchbase.lite.support.FileDirUtils;
 import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.util.Log;
-import com.couchbase.lite.util.LruCache;
 import com.couchbase.lite.util.TextUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Array;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -345,12 +343,25 @@ public final class Database {
             return;
         }
         File file = new File(path);
+        File fileJournal = new File(path + "-journal");
         File attachmentsFile = new File(getAttachmentStorePath());
 
         boolean deleteStatus = file.delete();
+        deleteStatus &= fileJournal.delete();
+
+        attachmentsFile = new File(getAttachmentStorePath());
+
 
         //recursively delete attachments path
         boolean deleteAttachmentStatus = FileDirUtils.deleteRecursive(attachmentsFile);
+
+        //recursively delete path where attachments stored( see getAttachmentStorePath())
+        int lastDotPosition = path.lastIndexOf('.');
+        if( lastDotPosition > 0 ) {
+            File attachmentsFileUpFolder = new File(path.substring(0, lastDotPosition));
+            FileDirUtils.deleteRecursive(attachmentsFileUpFolder);
+        }
+
 
         if (!deleteStatus) {
             throw new CouchbaseLiteException("Was not able to delete the database file", Status.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
for now cb lite leaves: DB_NAME folder and DB_NAME.cblite-journal file
