### PR TITLE
Fix crash in updateIndex when last doc is a design doc

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -480,7 +480,7 @@ public final class View {
                     sequence = cursor.getLong(1);
                     String docId = cursor.getString(2);
                     if(docId.startsWith("_design/")) {  // design docs don't get indexed!
-                        cursor.moveToNext();
+                        keepGoing = cursor.moveToNext();
                         continue;
                     }
                     String revId = cursor.getString(3);


### PR DESCRIPTION
The conditional that skips indexing design docs advances the cursor without updating the while loop condition (`keepGoing`). If the last row in the cursor is a design doc, this will cause the next loop iteration to read past the end of the cursor and throw a CursorIndexOutOfBoundsException.
