### PR TITLE
Document.getProperty should return null if a key doesn't exist

### DIFF
--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -231,7 +231,10 @@ public final class Document {
      */
     @InterfaceAudience.Public
     public Object getProperty(String key) {
-        return getCurrentRevision().getProperties().get(key);
+        if (getCurrentRevision().getProperties().containsKey(key)){
+            return getCurrentRevision().getProperties().get(key);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
on ios https://github.com/couchbase/couchbase-lite-ios/blob/master/Source/API/CBLDocument.m#L226
it return nil if a key doesn't exist.
