### PR TITLE
Fix unclosed Cursors

### DIFF
--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -44,9 +44,16 @@ public class Utils {
 
     public static byte[] byteArrayResultForQuery(SQLiteStorageEngine database, String query, String[] args) throws SQLException {
         byte[] result = null;
-        Cursor cursor = database.rawQuery(query, args);
-        if (cursor.moveToNext()) {
-            result = cursor.getBlob(0);
+        Cursor cursor = null;
+        try {
+            cursor = database.rawQuery(query, args);
+            if (cursor.moveToNext()) {
+                result = cursor.getBlob(0);
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
         }
         return result;
     }


### PR DESCRIPTION
When investigating an `android.database.CursorWindowAllocationException` crash, I came across [this StackOverflow post](http://stackoverflow.com/questions/21219039/android-database-cursorwindowallocationexception-when-moving-a-cursor) which suggests that they're caused by unclosed `Cursor`s. I took a look through CBL and found two that weren't being closed.
