### PR TITLE
Fix NPE when calling Manager.getDatabase concurrently

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -897,7 +897,7 @@ public final class Database {
      * @exclude
      */
     @InterfaceAudience.Private
-    public boolean open() {
+    public synchronized boolean open() {
         if(open) {
             return true;
         }

--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -7,7 +7,6 @@ import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.replicator.Puller;
 import com.couchbase.lite.replicator.Pusher;
 import com.couchbase.lite.replicator.Replication;
-import com.couchbase.lite.support.CouchbaseLiteHttpClientFactory;
 import com.couchbase.lite.support.FileDirUtils;
 import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.support.Version;
@@ -464,7 +463,7 @@ public final class Manager {
      * @exclude
      */
     @InterfaceAudience.Private
-    public Database getDatabaseWithoutOpening(String name, boolean mustExist) {
+    public synchronized Database getDatabaseWithoutOpening(String name, boolean mustExist) {
         Database db = databases.get(name);
         if(db == null) {
             if (!isValidDatabaseName(name)) {


### PR DESCRIPTION
Calling Manager.getDatabase() concurrently can lead to:

```
java.lang.NullPointerException
            at com.couchbase.lite.android.AndroidSQLiteStorageEngine.execSQL(AndroidSQLiteStorageEngine.java:95)
            at com.couchbase.lite.Database.initialize(Database.java:888)
            at com.couchbase.lite.Database.open(Database.java:918)
            at com.couchbase.lite.Manager.getDatabase(Manager.java:229)
```

This can be resolved by synchronizing
- Manager.getDatabaseWithoutOpening(), and
- Database.open().

The first ensures that both calls to getDatabase() get the same Database object back, and the second ensures that a Database is only opened once.

I chose this in favour of synchronizing Manager.getDatabase because these alone should help fix similar issues in other places (e.g. Manager.getExistingDatabase).
