### PR TITLE
Make / db names work in windows

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -402,7 +402,7 @@ public final class Manager {
         if((name == null) || (name.length() == 0) || Pattern.matches(LEGAL_CHARACTERS, name)) {
             return null;
         }
-        name = name.replace('/', ':');
+        name = name.replace('/', '!');
         String result = directoryFile.getPath() + File.separator + name + Manager.DATABASE_SUFFIX;
         return result;
     }


### PR DESCRIPTION
Problem - Couchbase replaces "/" characters in DB names with ":" characters. But ":" characters are illegal in Windows!

Proposed Solution - Use "!" character instead of ":" character

Justification - http://docs.couchdb.org/en/latest/api/database/common.html in the section on PUT 
/{db} defines the legal letters in a CouchDB db name. http://en.wikipedia.org/wiki/File_name#Reserved_characters_and_words identifies characters that are problematic in various file systems. Notice that ':' is listed. A character that is in neither list '!'. I actually did test it in Linux, OS/X, Windows 8 and Android KitKat and it worked just fine.

Problem with Solution - Any existing DBs that used '/' will stop working with this change since they won't be found. :(