### PR TITLE
Call validateRevision from forceInsert.

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -3842,7 +3842,7 @@ public final class Database {
 
             // Validate new revision
             RevisionInternal oldRev = null;
-            for(int i=0;i < historyCount; i++) {
+            for(int i = 1;i < historyCount; i++) {
                 oldRev = localRevs.revWithDocIdAndRevId(docId, revHistory.get(i));
                 if (oldRev != null) {
                     break;


### PR DESCRIPTION
Added the logic to call validateRevision in the forceInsert to check that the
current revision abides by the validation (if any). The logic is copied as
it exists in the iOS version. 
iOS Version is at: https://github.com/couchbase/couchbase-lite-ios/blob/master/Source/CBLDatabase%2BInsertion.m#L502

Issue Reference: https://github.com/couchbase/couchbase-lite-java-core/issues/206
