### PR TITLE
Make Database.addChangeListener idempotent

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -95,7 +95,7 @@ public final class Database {
 
     private BlobStore attachments;
     private Manager manager;
-    final private List<ChangeListener> changeListeners;
+    final private CopyOnWriteArrayList<ChangeListener> changeListeners;
     private Cache<String, Document> docCache;
     private List<DocumentChange> changesToNotify;
     private boolean postingChangeNotifications;
@@ -715,7 +715,7 @@ public final class Database {
      */
     @InterfaceAudience.Public
     public void addChangeListener(ChangeListener listener) {
-        changeListeners.add(listener);
+        changeListeners.addIfAbsent(listener);
     }
 
     /**


### PR DESCRIPTION
Adding a ChangeListener to a Database should be idempotent: no matter how many times the same listener is added, it should only be called once. This matches the behaviour of Java's `Observable`.

Without this fix, it's possible for the framework to add the same change listener more than once, resulting in changes getting processed more than once, which might have unexpected results.

How I noticed it: Start a continuous push replication, then put your phone in airplane mode, then bring it back and check the Database's `changeListeners` field: it will contain two copies of the same `Pusher`. Every change ends up getting handled twice from then on, and the problem multiplies every time you lose and regain connection. I don't think there is any consequence to it beyond some wasted cycles by the client (`Batcher`'s inbox is a `Set`, so it should ignore the dupes), but I thought it was worth fixing anyway.
