### PR TITLE
Fixes a problem with unclosed streams

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/Pusher.java
+++ b/src/main/java/com/couchbase/lite/replicator/Pusher.java
@@ -507,12 +507,12 @@ public final class Pusher extends Replication implements Database.ChangeListener
                 String base64Digest = (String) attachment.get("digest");
                 BlobKey blobKey = new BlobKey(base64Digest);
                 InputStream inputStream = blobStore.blobStreamForKey(blobKey);
-                inputStreamBodies.add(inputStream);
                 if (inputStream == null) {
                     Log.w(Log.TAG_SYNC, "Unable to find blob file for blobKey: %s - Skipping upload of multipart revision.", blobKey);
                     multiPart = null;
                 }
                 else {
+                    inputStreamBodies.add(inputStream);
                     String contentType = null;
                     if (attachment.containsKey("content_type")) {
                         contentType = (String) attachment.get("content_type");


### PR DESCRIPTION
The streams don't get closed during processing and so stay open and thus cause the test ReplicationTest/testPushReplicationCanMissDocs to fail on Windows but more general mean that anytime, anyone ever uses multi-part (which is used, for example, by the pusher) then the streams will be locked forever and attachment cleanup isn't possible.
