### PR TITLE
Improving logging on retry failures

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -251,6 +251,8 @@ public class RemoteRequest implements Runnable {
             Log.v(Log.TAG_SYNC, "%s: RemoteRequest calling retryRequest()", this);
             if (retryRequest()) {
                 return;
+            } else {
+                Log.e(Log.TAG_SYNC, "%s: RemoteRequest failed all retries, giving up.", this);
             }
         } catch (Exception e) {
             Log.e(Log.TAG_REMOTE_REQUEST, "%s: executeRequest() Exception: ", e, this);


### PR DESCRIPTION
I am running requests over TOR hidden services that can fail for very long times. So I need to track when we have a failure that causes a remote request to be given up on. Is there anywhere else a logging even or notification would occur if the replication couldn't get a connection established?
