### PR TITLE
Bug fix: getAttachment() now returns null after attachment deletion

### DIFF
--- a/src/main/java/com/couchbase/lite/Revision.java
+++ b/src/main/java/com/couchbase/lite/Revision.java
@@ -167,6 +167,11 @@ public abstract class Revision {
             return null;
         }
         Map<String, Object> attachmentMetadata = (Map<String, Object>) attachmentsMetadata.get(name);
+
+        if (attachmentMetadata == null) {
+            return null;
+        }
+
         return new Attachment(this, name, attachmentMetadata);
     }
 


### PR DESCRIPTION
This patch will resolve many problems related to applications dealing with attachments: getAttachment() should return null once the attachment is deleted. The corresponding test case has already been uploaded a month ago in RevisionsTest.java (couchbase-lite-android project).
