### PR TITLE
Make setting the logger level actually work

### DIFF
--- a/src/main/java/com/couchbase/lite/util/SystemLogger.java
+++ b/src/main/java/com/couchbase/lite/util/SystemLogger.java
@@ -18,9 +18,16 @@ package com.couchbase.lite.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.logging.Level;
 
 public class SystemLogger implements Logger {
     private final static java.util.logging.Logger logger = java.util.logging.Logger.getLogger("com.couchbase.lite");
+
+    static {
+        // Logging levels are filtered on top of this class but if we don't set this to all then all info and
+        // higher will get through no matter what levels are set higher in the chain.
+        logger.setLevel(Level.ALL);
+    }
 
     @Override
     public void v(String tag, String msg) {


### PR DESCRIPTION
Right now when we set the log level via the Couchbase logger it will (in Java anyway) bottom out into the the SystemLogger class. But the logger object in this class has its own logging level independent of the one we set in Couchbase and that level by default is 'info'. So it doesn't matter if you set the Couchbase logging level lower, logger won't let it through. The fix is to just set the logger's level to ALL and just depend on Couchbase's logger to handle filtering.
