### PR TITLE
Fix NPE when querying with prefetch

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -881,7 +881,9 @@ public final class View {
                                     null,
                                     EnumSet.noneOf(TDContentOptions.class)
                             );
-                            docContents = linkedDoc.getProperties();
+                            if (linkedDoc != null) {
+                                docContents = linkedDoc.getProperties();
+                            }
                         } else {
                             docContents = database.documentPropertiesFromJSON(
                                     cursor.getBlob(5),


### PR DESCRIPTION
When I want to get the referenced documents in a view query I need to set prefetch to true. If I then reference a document that doesn't exist (yet) in the DB, this causes a NPE in CBL, while CouchDB just returns "null" for the document.

This should fix that behaviour.
