### PR TITLE
Feature/issue 358 idle state

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationTrigger.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationTrigger.java
@@ -7,6 +7,7 @@ package com.couchbase.lite.replicator;
 enum ReplicationTrigger {
     START,
     WAITING_FOR_CHANGES,
+    RESUME, // send the RESUME trigger when a replication is IDLE but has new items to process
     GO_OFFLINE,
     GO_ONLINE,
     STOP_GRACEFUL,

--- a/src/main/java/com/couchbase/lite/support/BlockingQueueListener.java
+++ b/src/main/java/com/couchbase/lite/support/BlockingQueueListener.java
@@ -1,0 +1,11 @@
+package com.couchbase.lite.support;
+
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * Created by hideki on 12/17/14.
+ */
+public interface BlockingQueueListener<E> {
+    public enum EventType{ ADD, PUT, TAKE }
+    public void changed(EventType type, E e, BlockingQueue<E> queue);
+}

--- a/src/main/java/com/couchbase/lite/support/CustomLinkedBlockingQueue.java
+++ b/src/main/java/com/couchbase/lite/support/CustomLinkedBlockingQueue.java
@@ -1,0 +1,63 @@
+package com.couchbase.lite.support;
+
+import java.util.Collection;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Created by hideki on 12/17/14.
+ */
+public class CustomLinkedBlockingQueue<E> extends LinkedBlockingQueue<E> {
+    private BlockingQueueListener listener = null;
+
+    public CustomLinkedBlockingQueue() {
+    }
+
+    public CustomLinkedBlockingQueue(BlockingQueueListener listener) {
+        this.listener = listener;
+    }
+
+    public CustomLinkedBlockingQueue(int capacity) {
+        super(capacity);
+    }
+
+    public CustomLinkedBlockingQueue(Collection c) {
+        super(c);
+    }
+
+    public BlockingQueueListener getListener() {
+        return listener;
+    }
+
+    public void setListener(BlockingQueueListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void put(E e) throws InterruptedException {
+        super.put(e);
+
+        if(listener != null) {
+            listener.changed(BlockingQueueListener.EventType.PUT, e, this);
+        }
+    }
+
+    @Override
+    public boolean add(E e) {
+        boolean b = super.add(e);
+        if(listener != null) {
+            listener.changed(BlockingQueueListener.EventType.ADD, e, this);
+        }
+        return b;
+    }
+
+    @Override
+    public E take() throws InterruptedException {
+        E e = super.take();
+
+        if(listener != null) {
+            listener.changed(BlockingQueueListener.EventType.TAKE, e, this);
+        }
+
+        return e;
+    }
+}


### PR DESCRIPTION
Fix for #358  - Invalid state of Push replicator between IDLE and RUNNING under continuous mode

Solutions
1. Add state-machine trigger from IDLE to RUNNING
2. Extends LinkedBlockingQueue to support queue event listener
3. Call waitForPendingFuture() method and switch state from IDLE to RUNNING if necessary whenever Future task is added into pending queue.
4.  Switch state from RUNNING to IDLE if necessary at end of waitForPendingFuture() method
