### PR TITLE
Feature/issue 352 get session and checkpoint when retrying replication

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -423,7 +423,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         Map<String, Object> res = (Map<String, Object>) result;
 
                         if (e != null) {
-                            setError(e);
+                            setError(e, "/_all_docs?include_docs=true");
                             revisionFailed();
 
                             // TODO: There is a known bug caused by the line below, which is
@@ -433,6 +433,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             // completedChangesCount.addAndGet(bulkRevs.size());
 
                         } else {
+                            resetErrorRequest("/_all_docs?include_docs=true");
+
                             // Process the resulting rows' documents.
                             // We only add a document if it doesn't have attachments, and if its
                             // revID matches the one we asked for.

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -423,7 +423,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         Map<String, Object> res = (Map<String, Object>) result;
 
                         if (e != null) {
-                            setError(e, "/_all_docs?include_docs=true");
+                            setError(e);
                             revisionFailed();
 
                             // TODO: There is a known bug caused by the line below, which is
@@ -433,8 +433,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             // completedChangesCount.addAndGet(bulkRevs.size());
 
                         } else {
-                            resetErrorRequest("/_all_docs?include_docs=true");
-
                             // Process the resulting rows' documents.
                             // We only add a document if it doesn't have attachments, and if its
                             // revID matches the one we asked for.
@@ -972,11 +970,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     e.printStackTrace();
                 }
             }
-
         } catch (Exception e) {
             Log.e(Log.TAG_SYNC, "Exception waiting for pending futures: %s", e);
         }
-
     }
 
     @Override

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -366,12 +366,10 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 Log.v(Log.TAG_SYNC, "%s: got /_revs_diff response", this);
                 Map<String, Object> results = (Map<String, Object>) response;
                 if (e != null) {
-                    setError(e, "/_revs_diff");
+                    setError(e);
                     revisionFailed();
                 }
                 else {
-                    resetErrorRequest("/_revs_diff");
-
                     if (results.size() != 0) {
                         // Go through the list of local changes again, selecting the ones the destination server
                         // said were missing and mapping them to a JSON dictionary in the form _bulk_docs wants:
@@ -523,10 +521,9 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
 
                 }
                 if (e != null) {
-                    setError(e, "/_bulk_docs");
+                    setError(e);
                     revisionFailed();
                 } else {
-                    resetErrorRequest("/_bulk_docs");
                     Log.v(Log.TAG_SYNC, "%s: POSTed to _bulk_docs", PusherInternal.this);
                 }
                 addToCompletedChangesCount(numDocsToSend);
@@ -625,12 +622,11 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                             }
                         } else {
                             Log.e(Log.TAG_SYNC, "Exception uploading multipart request", e);
-                            setError(e, path);
+                            setError(e);
                             revisionFailed();
                         }
                     } else {
                         Log.v(Log.TAG_SYNC, "Uploaded multipart request.  Revision: %s", revision);
-                        resetErrorRequest(path);
                         removePending(revision);
                     }
                 } finally {
@@ -664,11 +660,10 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 new RemoteRequestCompletionBlock() {
                     public void onCompletion(HttpResponse httpResponse, Object result, Throwable e) {
                         if (e != null) {
-                            setError(e, path);
+                            setError(e);
                             revisionFailed();
                         } else {
                             Log.v(Log.TAG_SYNC, "%s: Sent %s (JSON), response=%s", this, rev, result);
-                            resetErrorRequest(path);
                             removePending(rev);
                         }
                     }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -71,7 +71,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
 
     private static int lastSessionID = 0;
 
-    public static int RETRY_DELAY = 5; // #define kRetryDelay 60.0 in CBL_Replicator.m
+    public static int RETRY_DELAY = 60; // #define kRetryDelay 60.0 in CBL_Replicator.m
 
     protected Replication parentReplication;
     protected Database db;

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class RemoteRequestRetry<T> implements Future<T> {
 
     public static int MAX_RETRIES = 3;  // total number of attempts = 4 (1 initial + MAX_RETRIES)
-    public static int RETRY_DELAY_MS = 10 * 1000;
+    public static int RETRY_DELAY_MS = 4 * 1000; // 4 sec
 
     protected ScheduledExecutorService workExecutor;
     protected ExecutorService requestExecutor;  // must have more than one thread
@@ -62,6 +63,9 @@ public class RemoteRequestRetry<T> implements Future<T> {
     protected Map<String, Object> requestHeaders;
 
     private RemoteRequestType requestType;
+
+    // for Retry task
+    ScheduledFuture retryFuture = null;
 
     /**
      * The kind of RemoteRequest that will be created on each retry attempt
@@ -190,6 +194,7 @@ public class RemoteRequestRetry<T> implements Future<T> {
 
             } else {
 
+                // Only retry if error is  TransientError (5xx).
                 if (isTransientError(httpResponse, e)) {
                     if (retryCount >= MAX_RETRIES) {
                         Log.d(Log.TAG_SYNC, "%s: RemoteRequestRetry failed, but transient error.  retries exhausted. url: %s", this, url);
@@ -202,19 +207,24 @@ public class RemoteRequestRetry<T> implements Future<T> {
                         requestHttpResponse = httpResponse;
                         requestResult = result;
                         requestThrowable = e;
-
                         retryCount += 1;
-
-                        submit();
-
+                        // Another choice: android.os.Handler.postDelayed(Runnable r, long delayMillis) is another choice. But only for Android.
+                        // reuse workExecutor (ScheduledExecutorService) to retry replication
+                        double dDelay = RETRY_DELAY_MS * (Math.pow((double) 2, (double) (retryCount-1)));
+                        long lDelay = (dDelay > (double) Long.MAX_VALUE) ? Long.MAX_VALUE : (long) dDelay;
+                        retryFuture = workExecutor.schedule(new Runnable() {
+                            @Override
+                            public void run() {
+                                submit();
+                            }
+                        }, lDelay, TimeUnit.MILLISECONDS); // delay init_delay * 2^retry ms
                     }
+
                 } else {
                     Log.d(Log.TAG_SYNC, "%s: RemoteRequestRetry failed, non-transient error.  NOT retrying. url: %s", this, url);
                     // this isn't a transient error, so there's no point in retrying
                     completed(httpResponse, result, e);
                 }
-
-
             }
         }
     };
@@ -256,6 +266,11 @@ public class RemoteRequestRetry<T> implements Future<T> {
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
+        // If RemoteRequestRetry is canceled, make sure if retry future is also canceled.
+        if(retryFuture != null && !retryFuture.isCancelled()){
+            retryFuture.cancel(mayInterruptIfRunning);
+        }
+
         return false;
     }
 

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -208,16 +208,14 @@ public class RemoteRequestRetry<T> implements Future<T> {
                         requestResult = result;
                         requestThrowable = e;
                         retryCount += 1;
-                        // Another choice: android.os.Handler.postDelayed(Runnable r, long delayMillis) is another choice. But only for Android.
-                        // reuse workExecutor (ScheduledExecutorService) to retry replication
-                        double dDelay = RETRY_DELAY_MS * (Math.pow((double) 2, (double) (retryCount-1)));
-                        long lDelay = (dDelay > (double) Long.MAX_VALUE) ? Long.MAX_VALUE : (long) dDelay;
+                        // delay * 2 << retry
+                        long delay = RETRY_DELAY_MS * (long)Math.pow((double)2, (double)Math.min(retryCount-1, MAX_RETRIES));
                         retryFuture = workExecutor.schedule(new Runnable() {
                             @Override
                             public void run() {
                                 submit();
                             }
-                        }, lDelay, TimeUnit.MILLISECONDS); // delay init_delay * 2^retry ms
+                        }, delay, TimeUnit.MILLISECONDS); // delay init_delay * 2^retry ms
                     }
 
                 } else {

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -1,7 +1,6 @@
 package com.couchbase.lite.util;
 
 import com.couchbase.lite.CouchbaseLiteException;
-import com.couchbase.lite.Database;
 import com.couchbase.lite.Status;
 import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.storage.Cursor;
@@ -28,6 +27,34 @@ public class Utils {
             return obj2 == null;
         }
     }
+
+    /**
+     * in CBLMisc.m
+     * BOOL CBLIsPermanentError( NSError* error )
+     */
+    public static boolean isPermanentError(Throwable throwable){
+        if (throwable instanceof CouchbaseLiteException) {
+            CouchbaseLiteException e = (CouchbaseLiteException) throwable;
+            return isPermanentError(e.getCBLStatus().getCode());
+        } else if (throwable instanceof HttpResponseException) {
+            HttpResponseException e = (HttpResponseException) throwable;
+            return isPermanentError(e.getStatusCode());
+        } else {
+            return false;
+        }
+    }
+    /**
+     * in CBLMisc.m
+     * BOOL CBLIsPermanentError( NSError* error )
+     */
+    public static boolean isPermanentError(int code){
+        // TODO: make sure if 406 is acceptable error
+        // 406 - in Test cases, server return 406 because of CouchDB API
+        //       http://docs.couchdb.org/en/latest/api/database/bulk-api.html
+        //       GET /{db}/_all_docs or POST /{db}/_all_docs
+        return (code >= 400 && code <= 405) || (code >= 407 && code <= 499);
+    }
+
 
     public static boolean isTransientError(Throwable throwable) {
 


### PR DESCRIPTION
NOTE: This PR depends on #363 (issue number #299)

Fix #352 Get session and checkpoint when retrying replications

- This fix depends on the fix of #299
- Case 1 - By fixing #299, case 1 is also addressed.
- Case 2 - iOS version: stop replicator immediately when setError() was called with permanent error. But, for Core Java version, stop replicator when state becomes IDLE.
              -  Two test cases which calls /{db}/_all_docs are broken if stop replicator for HTTP error 406, because test case does not implement /{db}/_all_docs. Because of this, current version eliminate 406 http error from permanent error list.