### PR TITLE
Feature/issue 316 fail to resolve old conflicts

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -3651,7 +3651,7 @@ public final class Database {
                 //    return null;
                 Log.w(Database.TAG, "Duplicate rev insertion: " + docId + " / " + newRevId);
                 newRev.setBody(null);
-                // don't return yet; update the parent's current just to be sure (see #316 (iOS #501))
+                // don't return yet; update the parent's current just to be sure (see #316 (iOS #509))
             }
 
             // Make replaced rev non-current:


### PR DESCRIPTION
Fix #316  Get session and checkpoint when retrying replications

- Because reproduce steps are not clear now, so no test case for this fix.
- Basically ported fix for iOS - https://github.com/couchbase/couchbase-lite-ios/commit/7b3fca59e88b2281802425fa0c8d3659c8186a6a#diff-bb5cfc8dca22d97f47291aa05a9f5bebR350
  - String winningRevIDOfDoc(long docNumericId, AtomicBoolean outIsDeleted, AtomicBoolean outIsConflict) throws CouchbaseLiteException throws exception if encountered error. No change.
  - In public RevisionInternal putRevision(RevisionInternal oldRev, String prevRevId, boolean allowConflict, Status resultStatus) throws CouchbaseLiteException, if newSequence <= 0 (conflict), return after updating parentSequence.
  - Because of current AndroidSQLiteStorageEngine implementation, unable to get detailed error code of SQLite. we might need to work for it later.