### PR TITLE
Fix #304 Implement Query.sort

### DIFF
--- a/src/main/java/com/couchbase/lite/QueryEnumerator.java
+++ b/src/main/java/com/couchbase/lite/QueryEnumerator.java
@@ -2,6 +2,8 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.internal.InterfaceAudience;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -133,4 +135,12 @@ public class QueryEnumerator implements Iterator<QueryRow> {
     }
 
 
+    /**
+     * in CBLQuery.m
+     * - (void) sortUsingDescriptors: (NSArray*)sortDescriptors
+     */
+    public void sortUsingDescriptors(Comparator<QueryRow> sortDescriptors){
+        // Now the sorting is trivial:
+        Collections.sort(rows, sortDescriptors);
+    }
 }

--- a/src/main/java/com/couchbase/lite/QueryOptions.java
+++ b/src/main/java/com/couchbase/lite/QueryOptions.java
@@ -19,6 +19,7 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.Database.TDContentOptions;
 
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -50,6 +51,7 @@ public class QueryOptions {
     private String startKeyDocId;
     private String endKeyDocId;
 
+    private Comparator<QueryRow> sortDescriptors;
     private Predicate<QueryRow> postFilter;
 
 
@@ -213,4 +215,11 @@ public class QueryOptions {
         this.postFilter = postFilter;
     }
 
+    public Comparator<QueryRow> getSortDescriptors() {
+        return sortDescriptors;
+    }
+
+    public void setSortDescriptors(Comparator<QueryRow> sortDescriptors) {
+        this.sortDescriptors = sortDescriptors;
+    }
 }


### PR DESCRIPTION
- Java does not have completely equivalent implementation of NSSortDescriptor. Instead of NSSortDescriptor, we use java.util.Comparator.
- Comparator is primitive interface. So CBL Java Core can not provide high-level sorting descriptor like CBL iOS implementation.