### PR TITLE
fix Android CloseGuard error message

### DIFF
--- a/src/main/java/com/couchbase/lite/util/LoggerFactory.java
+++ b/src/main/java/com/couchbase/lite/util/LoggerFactory.java
@@ -33,18 +33,23 @@ public class LoggerFactory {
                 // Return default System logger.
                 Log.d(Database.TAG, "Unable to load %s. Falling back to SystemLogger", resource);
                 return new SystemLogger();
+            } else {
+              try {
+                byte[] bytes = TextUtils.read(inputStream);
+                classname = new String(bytes);
+                if (classname == null || classname.isEmpty()) {
+                    // Return default System logger.
+                    Log.d(Database.TAG, "Unable to load %s. Falling back to SystemLogger", resource);
+                    return new SystemLogger();
+                }
+                Log.v(Database.TAG, "Loading logger: %s", classname);
+                Class clazz = Class.forName(classname);
+                Logger logger = (Logger) clazz.newInstance();
+                return logger;
+              } finally {
+                inputStream.close();
+              }
             }
-            byte[] bytes = TextUtils.read(inputStream);
-            classname = new String(bytes);
-            if (classname == null || classname.isEmpty()) {
-                // Return default System logger.
-                Log.d(Database.TAG, "Unable to load %s. Falling back to SystemLogger", resource);
-                return new SystemLogger();
-            }
-            Log.v(Database.TAG, "Loading logger: %s", classname);
-            Class clazz = Class.forName(classname);
-            Logger logger = (Logger) clazz.newInstance();
-            return logger;
         } catch (Exception e) {
             throw new RuntimeException("Failed to logger.  Resource: " + resource + " classname: " + classname, e);
         }


### PR DESCRIPTION
this patch fixes the Android error message: 'A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.'
the problem was that an InputStream was opened without later calling close(). The full error message looks like this:

E/StrictMode﹕ A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
    java.lang.Throwable: Explicit termination method 'end' not called
            at dalvik.system.CloseGuard.open(CloseGuard.java:184)
            at java.util.zip.Inflater.<init>(Inflater.java:82)
            at java.util.zip.ZipFile.getInputStream(ZipFile.java:270)
            at java.util.jar.JarFile.getInputStream(JarFile.java:388)
            at libcore.net.url.JarURLConnectionImpl.getInputStream(JarURLConnectionImpl.java:226)
            at java.net.URL.openStream(URL.java:462)
            at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:436)
            at com.couchbase.lite.util.LoggerFactory.createLogger(LoggerFactory.java:31)
            at com.couchbase.lite.util.Log.<clinit>(Log.java:23)
            at com.couchbase.lite.Manager.<init>(Manager.java:119)