### PR TITLE
Fix #360 - REST API need a way to setCookie

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -615,7 +615,11 @@ public final class Manager {
                 repl.setAuthenticator(authorizer);
             }
 
-            Map<String, Object> headers = (Map) properties.get("headers");
+            Map<String, Object> headers = null;
+            if(remoteMap != null){
+                headers = (Map)remoteMap.get("headers");
+            }
+
             if (headers != null && !headers.isEmpty()) {
                 repl.setHeaders(headers);
             }


### PR DESCRIPTION
* Problem: set header was inconsistence with iOS. Follow CouchDB Replication API - http://wiki.apache.org/couchdb/Replication#Username_Workaround_.28older_CouchDBs_only.29
* headers should be in target or source property
* No Unit Test - I tested from PhoneGap ToDo Lite Sample

Example to set cookie in header for replicator
```
    var remote = {
        headers: {
            Cookie: session_body.cookie_name + '=' + session_body.session_id
        },
        url : config.site.syncUrl
    },
    push = {
        source : appDbName,
        target : remote,
        continuous : true
    }, pull = {
        target : appDbName,
        source : remote,
        continuous : true
    }
```

