### PR TITLE
fix #172 support gzip

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -12,6 +12,7 @@ import com.couchbase.lite.support.RemoteRequest;
 import com.couchbase.lite.support.RemoteRequestCompletionBlock;
 import com.couchbase.lite.util.CollectionUtils;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -175,13 +176,11 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                         inputStream = entity.getContent();
 
                         // decompress if contentEncoding is gzip
-                        Header contentEncoding = entity.getContentEncoding();
-                        if(contentEncoding != null && contentEncoding.getValue().contains("gzip")){
+                        if(Utils.isGzip(entity)){
                             inputStream = new GZIPInputStream(inputStream);
                         }
 
                         try {
-
                             fullBody = Manager.getObjectMapper().readValue(inputStream,
                                     Object.class);
                             respondWithResult(fullBody, error, response);

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -342,6 +342,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
         dl.setAuthenticator(getAuthenticator());
 
+        // set compressed request - gzip
+        dl.setCompressedRequest(canSendCompressedRequests());
+
         Future future = remoteRequestExecutor.submit(dl);
         pendingFutures.add(future);
 

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -13,6 +13,7 @@ import com.couchbase.lite.Status;
 import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.support.HttpClientFactory;
+import com.couchbase.lite.support.RemoteRequest;
 import com.couchbase.lite.support.RemoteRequestCompletionBlock;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.URIUtils;
@@ -568,7 +569,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                         byte[] compressed = null;
                         String contentEncoding = null;
 
-                        if(uncompressed.length > 100 && canSendCompressedRequests()){
+                        if(uncompressed.length > RemoteRequest.MIN_JSON_LENGTH_TO_COMPRESS && canSendCompressedRequests()){
                             compressed = Utils.compressByGzip(uncompressed);
                             if(compressed.length < uncompressed.length){
                                 contentEncoding = "gzip";

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -569,7 +569,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                         String contentEncoding = null;
 
                         if(uncompressed.length > 100 && canSendCompressedRequests()){
-                            compressed = Utils.generateGzippedData(uncompressed);
+                            compressed = Utils.compressByGzip(uncompressed);
                             if(compressed.length < uncompressed.length){
                                 contentEncoding = "gzip";
                             }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -541,9 +541,9 @@ abstract class ReplicationInternal implements BlockingQueueListener{
             }
         });
 
-        Future future = request.submit();
-        return future;
 
+        Future future = request.submit(canSendCompressedRequests());
+        return future;
     }
 
     /**
@@ -965,6 +965,18 @@ abstract class ReplicationInternal implements BlockingQueueListener{
     abstract protected void processInbox(RevisionList inbox);
 
     /**
+     * gzip
+     *
+     * in CBL_Replicator.m
+     * - (BOOL) canSendCompressedRequests
+     */
+    public boolean canSendCompressedRequests(){
+        // https://github.com/couchbase/couchbase-lite-ios/issues/240#issuecomment-32506552
+        // gzip upload is only enabled when the server is Sync Gateway 0.92 or later
+        return serverIsSyncGatewayVersion("0.92");
+    }
+
+    /**
      * After successfully authenticating and getting remote checkpoint,
      * begin the work of transferring documents.
      */
@@ -1204,7 +1216,6 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                 String versionString = serverType.substring(prefix.length());
                 return versionString.compareTo(minVersion) >= 0;
             }
-
         }
         return false;
     }
@@ -1547,7 +1558,6 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                         }
                     }).start();
                 }
-
             }
         }
     }

--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -63,7 +63,6 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
             // Multipart, so initialize the parser:
             multipartReader = new MultipartReader(contentType, this);
             attachmentsByName = new HashMap<String, BlobStoreWriter>();
-            attachmentsByName = new HashMap<String, BlobStoreWriter>();
             attachmentsByMd5Digest = new HashMap<String, BlobStoreWriter>();
         }
         else if (contentType == null ||
@@ -81,8 +80,7 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
     }
     protected void startJSONBufferWithHeaders(Map<String, String> headers){
         jsonBuffer = new ByteArrayBuffer(1024);
-        String contentEncoding = headers.get("Content-Encoding");
-        jsonCompressed = contentEncoding != null &&  contentEncoding.indexOf("gzip") >= 0;
+        jsonCompressed = Utils.isGzip(headers.get("Content-Encoding"));
     }
 
     public void appendData(byte[] data) {

--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -5,6 +5,7 @@ import com.couchbase.lite.Database;
 import com.couchbase.lite.Manager;
 import com.couchbase.lite.Misc;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.util.ByteArrayBuffer;
@@ -21,6 +22,7 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
     private MultipartReader multipartReader;
     private BlobStoreWriter curAttachment;
     private ByteArrayBuffer jsonBuffer;
+    private boolean jsonCompressed;
     private Map<String, Object> document;
     private Database database;
     private Map<String, BlobStoreWriter> attachmentsByName;
@@ -37,26 +39,50 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
     }
 
     public void parseJsonBuffer() {
+        byte[] json = jsonBuffer.toByteArray();
+
+        if(jsonCompressed){
+            json = Utils.decompressByGzip(json);
+            if(json == null){
+                throw new IllegalStateException("Received corrupt gzip-encoded JSON part");
+            }
+        }
+
         try {
-            document = Manager.getObjectMapper().readValue(jsonBuffer.toByteArray(), Map.class);
+            document = Manager.getObjectMapper().readValue(json, Map.class);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to parse json buffer", e);
         }
+
         jsonBuffer = null;
     }
 
-    public void setContentType(String contentType) {
-        if (contentType.startsWith("multipart/")) {
+    public void setHeaders(Map<String, String> headers){
+        String contentType = headers.get("Content-Type");
+        if(contentType.startsWith("multipart/")){
+            // Multipart, so initialize the parser:
             multipartReader = new MultipartReader(contentType, this);
             attachmentsByName = new HashMap<String, BlobStoreWriter>();
+            attachmentsByName = new HashMap<String, BlobStoreWriter>();
             attachmentsByMd5Digest = new HashMap<String, BlobStoreWriter>();
-        } else if (contentType == null || contentType.startsWith("application/json")
-                    || contentType.startsWith("text/plain")) {
+        }
+        else if (contentType == null ||
+                contentType.startsWith("application/json") ||
+                contentType.startsWith("text/plain")) {
+
             // No multipart, so no attachments. Body is pure JSON. (We allow text/plain because CouchDB
             // sends JSON responses using the wrong content-type.)
-        } else {
-            throw new IllegalArgumentException("contentType must start with multipart/");
+            startJSONBufferWithHeaders(headers);
         }
+        else {
+            throw new IllegalArgumentException("Unknown/invalid MIME type");
+        }
+
+    }
+    protected void startJSONBufferWithHeaders(Map<String, String> headers){
+        jsonBuffer = new ByteArrayBuffer(1024);
+        String contentEncoding = headers.get("Content-Encoding");
+        jsonCompressed = contentEncoding != null &&  contentEncoding.indexOf("gzip") >= 0;
     }
 
     public void appendData(byte[] data) {
@@ -173,7 +199,7 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
     public void startedPart(Map<String, String> headers) {
 
         if (document == null) {
-           jsonBuffer = new ByteArrayBuffer(1024);
+            startJSONBufferWithHeaders(headers);
         }
         else {
             curAttachment = database.getAttachmentWriter();

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
@@ -44,7 +44,7 @@ public class RemoteMultipartRequest extends RemoteRequest {
             throw new IllegalArgumentException("Invalid request method: " + method);
         }
 
-        request.addHeader("Accept", "*/*");
+        request.addHeader("Accept", "*/*"); // should be "application/json"??
 
         executeRequest(httpClient, request);
 

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
@@ -25,7 +25,6 @@ public class RemoteMultipartRequest extends RemoteRequest {
 
     @Override
     public void run() {
-
         HttpClient httpClient = clientFactory.getHttpClient();
 
         preemptivelySetAuthCredentials(httpClient);
@@ -44,11 +43,8 @@ public class RemoteMultipartRequest extends RemoteRequest {
             throw new IllegalArgumentException("Invalid request method: " + method);
         }
 
-        request.addHeader("Accept", "*/*"); // should be "application/json"??
+        request.addHeader("Accept", "*/*");
 
         executeRequest(httpClient, request);
-
     }
-
-
 }

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -344,7 +344,7 @@ public class RemoteRequest implements Runnable {
         }
 
         // Gzipping
-        byte[] encodedBytes = Utils.generateGzippedData(bodyBytes);
+        byte[] encodedBytes = Utils.compressByGzip(bodyBytes);
 
         if(encodedBytes == null || encodedBytes.length >= bodyBytes.length) {
             return null;

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -340,7 +340,7 @@ public class RemoteRequest implements Runnable {
      * - (BOOL) compressBody
      */
     protected ByteArrayEntity setCompressedBody(byte[] bodyBytes){
-        if(bodyBytes.length < 100){
+        if(bodyBytes.length < MIN_JSON_LENGTH_TO_COMPRESS){
             return null;
         }
 

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -6,6 +6,7 @@ import com.couchbase.lite.auth.Authenticator;
 import com.couchbase.lite.auth.AuthenticatorImpl;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.URIUtils;
+import com.couchbase.lite.util.Utils;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
@@ -30,13 +31,11 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.protocol.HttpContext;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.zip.GZIPOutputStream;
 
 
 /**
@@ -345,7 +344,7 @@ public class RemoteRequest implements Runnable {
         }
 
         // Gzipping
-        byte[] encodedBytes = generateGzippedData(bodyBytes);
+        byte[] encodedBytes = Utils.generateGzippedData(bodyBytes);
 
         if(encodedBytes == null || encodedBytes.length >= bodyBytes.length) {
             return null;
@@ -361,25 +360,5 @@ public class RemoteRequest implements Runnable {
         ByteArrayEntity entity = new ByteArrayEntity(bodyBytes);
         entity.setContentType("application/json");
         return entity;
-    }
-
-
-    protected byte[] generateGzippedData(byte[] sourceBytes){
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try{
-            try {
-                GZIPOutputStream gzip = new GZIPOutputStream(out);
-                gzip.write(sourceBytes);
-                gzip.close();
-            }
-            catch (IOException ex){
-                return null;
-            }
-
-            return  out.toByteArray();
-        }
-        finally {
-            try{ out.close(); }catch(IOException ex){}
-        }
     }
 }

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ScheduledExecutorService;
  * @exclude
  */
 public class RemoteRequest implements Runnable {
+    public static final int MIN_JSON_LENGTH_TO_COMPRESS = 100;
 
     protected ScheduledExecutorService workExecutor;
     protected final HttpClientFactory clientFactory;
@@ -323,7 +324,7 @@ public class RemoteRequest implements Runnable {
                 Log.e(Log.TAG_REMOTE_REQUEST, "Error serializing body of request", e);
             }
             ByteArrayEntity entity = null;
-            if(isCompressedRequest()){
+            if(isCompressedRequest() && bodyBytes.length > MIN_JSON_LENGTH_TO_COMPRESS){
                 entity = setCompressedBody(bodyBytes);
             }
             if(entity == null){

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -106,8 +106,19 @@ public class RemoteRequestRetry<T> implements Future<T> {
     }
 
     public Future submit() {
+        return submit(false);
+    }
+
+    /**
+     * @param gzip true - send gzipped request
+     */
+    public Future submit(boolean gzip) {
 
         RemoteRequest request = generateRemoteRequest();
+
+        if(gzip){
+            request.setCompressedRequest(true);
+        }
 
         Future future = requestExecutor.submit(request);
         pendingRequests.add(future);

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -10,6 +10,10 @@ import com.couchbase.lite.storage.SQLiteStorageEngine;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPOutputStream;
+
 public class Utils {
 
     /**
@@ -154,4 +158,22 @@ public class Utils {
         return orig.substring(0, maxLength);
     }
 
+    public static byte[] generateGzippedData(byte[] sourceBytes){
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try{
+            try {
+                GZIPOutputStream gzip = new GZIPOutputStream(out);
+                gzip.write(sourceBytes);
+                gzip.close();
+            }
+            catch (IOException ex){
+                return null;
+            }
+
+            return  out.toByteArray();
+        }
+        finally {
+            try{ out.close(); }catch(IOException ex){}
+        }
+    }
 }

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -7,11 +7,17 @@ import com.couchbase.lite.storage.Cursor;
 import com.couchbase.lite.storage.SQLException;
 import com.couchbase.lite.storage.SQLiteStorageEngine;
 
+import org.apache.http.Header;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 public class Utils {
@@ -158,7 +164,8 @@ public class Utils {
         return orig.substring(0, maxLength);
     }
 
-    public static byte[] generateGzippedData(byte[] sourceBytes){
+    // to gzip
+    public static byte[] compressByGzip(byte[] sourceBytes){
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try{
             try {
@@ -175,5 +182,55 @@ public class Utils {
         finally {
             try{ out.close(); }catch(IOException ex){}
         }
+    }
+    // from gzip
+    public static int CHUNK_SIZE = 8192; // 1024 * 8
+    public static byte[] decompressByGzip(byte[] sourceBytes){
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            try {
+                byte[] buffer = new byte[CHUNK_SIZE];
+                ByteArrayInputStream in = new ByteArrayInputStream(sourceBytes);
+                GZIPInputStream gzip = new GZIPInputStream(in);
+                int len = 0;
+                while ((len = gzip.read(buffer, 0, CHUNK_SIZE)) != -1) {
+                    out.write(buffer, 0, len);
+                }
+            }
+            catch (IOException ex){
+                return null;
+            }
+            return out.toByteArray();
+        }
+        finally {
+            try{ out.close(); }catch(IOException ex){}
+        }
+    }
+    public static byte[] decompressByGzip(InputStream sourceStream){
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            try {
+                byte[] buffer = new byte[CHUNK_SIZE];
+                GZIPInputStream gzip = new GZIPInputStream(sourceStream);
+                int len = 0;
+                while ((len = gzip.read(buffer, 0, CHUNK_SIZE)) != -1) {
+                    out.write(buffer, 0, len);
+                }
+            }
+            catch (IOException ex){
+                return null;
+            }
+            return out.toByteArray();
+        }
+        finally {
+            try{ out.close(); }catch(IOException ex){}
+        }
+    }
+    public static Map<String, String> headersToMap(Header[] headers){
+        Map<String, String> map = new HashMap<String, String>();
+        for(int i = 0; i < headers.length; i++){
+            map.put(headers[i].getName(), headers[i].getValue());
+        }
+        return map;
     }
 }

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -8,6 +8,7 @@ import com.couchbase.lite.storage.SQLException;
 import com.couchbase.lite.storage.SQLiteStorageEngine;
 
 import org.apache.http.Header;
+import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 
@@ -161,6 +162,21 @@ public class Utils {
             return orig;
         }
         return orig.substring(0, maxLength);
+    }
+
+    // check if contentEncoding is gzip
+    public static boolean isGzip(HttpEntity entity){
+        return isGzip(entity.getContentEncoding());
+    }
+
+    // check if contentEncoding is gzip
+    public static boolean isGzip(Header contentEncoding){
+        return contentEncoding != null && isGzip(contentEncoding.getValue());
+    }
+
+    // check if contentEncoding is gzip
+    public static boolean isGzip(String contentEncoding){
+        return contentEncoding != null && contentEncoding.contains("gzip");
     }
 
     // to gzip

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -14,7 +14,6 @@ import org.apache.http.client.HttpResponseException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
@@ -183,6 +182,7 @@ public class Utils {
             try{ out.close(); }catch(IOException ex){}
         }
     }
+
     // from gzip
     public static int CHUNK_SIZE = 8192; // 1024 * 8
     public static byte[] decompressByGzip(byte[] sourceBytes){
@@ -206,26 +206,7 @@ public class Utils {
             try{ out.close(); }catch(IOException ex){}
         }
     }
-    public static byte[] decompressByGzip(InputStream sourceStream){
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try {
-            try {
-                byte[] buffer = new byte[CHUNK_SIZE];
-                GZIPInputStream gzip = new GZIPInputStream(sourceStream);
-                int len = 0;
-                while ((len = gzip.read(buffer, 0, CHUNK_SIZE)) != -1) {
-                    out.write(buffer, 0, len);
-                }
-            }
-            catch (IOException ex){
-                return null;
-            }
-            return out.toByteArray();
-        }
-        finally {
-            try{ out.close(); }catch(IOException ex){}
-        }
-    }
+
     public static Map<String, String> headersToMap(Header[] headers){
         Map<String, String> map = new HashMap<String, String>();
         for(int i = 0; i < headers.length; i++){

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/FormBodyPart.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/FormBodyPart.java
@@ -58,6 +58,7 @@ public class FormBodyPart {
         generateContentDisp(body);
         generateContentType(body);
         generateTransferEncoding(body);
+        generateContentEncoding(body);
     }
 
     public String getName() {
@@ -103,5 +104,9 @@ public class FormBodyPart {
     protected void generateTransferEncoding(final ContentBody body) {
         addField(MIME.CONTENT_TRANSFER_ENC, body.getTransferEncoding()); // TE cannot be null
     }
-
+    protected void generateContentEncoding(final ContentBody body) {
+        if(body.getContentEncoding() != null) {
+            addField(MIME.CONTENT_ENCODING, body.getContentEncoding());
+        }
+    }
 }

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/MIME.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/MIME.java
@@ -38,6 +38,7 @@ public final class MIME {
     public static final String CONTENT_TYPE          = "Content-Type";
     public static final String CONTENT_TRANSFER_ENC  = "Content-Transfer-Encoding";
     public static final String CONTENT_DISPOSITION   = "Content-Disposition";
+    public static final String CONTENT_ENCODING      = "Content-Encoding";
 
     public static final String ENC_8BIT              = "8bit";
     public static final String ENC_BINARY            = "binary";

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/content/AbstractContentBody.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/content/AbstractContentBody.java
@@ -65,4 +65,5 @@ public abstract class AbstractContentBody implements ContentBody {
         return this.subType;
     }
 
+    public String getContentEncoding(){return null;}
 }

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/content/ByteArrayBody.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/content/ByteArrayBody.java
@@ -26,11 +26,10 @@
  */
 package com.couchbase.org.apache.http.entity.mime.content;
 
+import com.couchbase.org.apache.http.entity.mime.MIME;
+
 import java.io.IOException;
 import java.io.OutputStream;
-
-import com.couchbase.org.apache.http.entity.mime.MIME;
-import com.couchbase.org.apache.http.entity.mime.content.AbstractContentBody;
 
 /**
  * Body part that is built using a byte array containing a file.
@@ -94,5 +93,4 @@ public class ByteArrayBody extends AbstractContentBody {
     public long getContentLength() {
         return data.length;
     }
-
 }

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/content/ContentDescriptor.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/content/ContentDescriptor.java
@@ -86,4 +86,6 @@ public interface ContentDescriptor {
      */
     long getContentLength();
 
+    // Content-Encoding
+    String getContentEncoding();
 }

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/content/FileBody.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/content/FileBody.java
@@ -27,13 +27,13 @@
 
 package com.couchbase.org.apache.http.entity.mime.content;
 
+import com.couchbase.org.apache.http.entity.mime.MIME;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import com.couchbase.org.apache.http.entity.mime.MIME;
 
 /**
  *
@@ -129,5 +129,4 @@ public class FileBody extends AbstractContentBody {
     public File getFile() {
         return this.file;
     }
-
 }

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/content/InputStreamBody.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/content/InputStreamBody.java
@@ -27,11 +27,11 @@
 
 package com.couchbase.org.apache.http.entity.mime.content;
 
+import com.couchbase.org.apache.http.entity.mime.MIME;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import com.couchbase.org.apache.http.entity.mime.MIME;
 
 /**
  *
@@ -108,5 +108,4 @@ public class InputStreamBody extends AbstractContentBody {
     public String getFilename() {
         return this.filename;
     }
-
 }

--- a/src/main/java/com/couchbase/org/apache/http/entity/mime/content/StringBody.java
+++ b/src/main/java/com/couchbase/org/apache/http/entity/mime/content/StringBody.java
@@ -27,6 +27,8 @@
 
 package com.couchbase.org.apache.http.entity.mime.content;
 
+import com.couchbase.org.apache.http.entity.mime.MIME;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,8 +38,6 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
-import com.couchbase.org.apache.http.entity.mime.MIME;
-
 /**
  *
  * @since 4.0
@@ -46,6 +46,7 @@ public class StringBody extends AbstractContentBody {
 
     private final byte[] content;
     private final Charset charset;
+    private String contentEncoding = null;
 
     /**
      * @since 4.1
@@ -99,6 +100,20 @@ public class StringBody extends AbstractContentBody {
         this.content = text.getBytes(charset.name());
         this.charset = charset;
     }
+
+    public StringBody(final byte[] content, final String mimeType, Charset charset){
+        super(mimeType);
+        this.content = content;
+        this.charset = charset;
+    }
+
+    public StringBody(final byte[] content, final String mimeType, Charset charset, String contentEncoding){
+        super(mimeType);
+        this.content = content;
+        this.charset = charset;
+        this.contentEncoding = contentEncoding;
+    }
+
 
     /**
      * Create a StringBody from the specified text and character set.
@@ -154,6 +169,9 @@ public class StringBody extends AbstractContentBody {
     }
 
     public String getTransferEncoding() {
+        if(contentEncoding!= null){
+            return contentEncoding;
+        }
         return MIME.ENC_8BIT;
     }
 
@@ -169,4 +187,8 @@ public class StringBody extends AbstractContentBody {
         return null;
     }
 
+    @Override
+    public String getContentEncoding() {
+        return contentEncoding;
+    }
 }


### PR DESCRIPTION
Gzip support for replication #172 

- enable compression if sync gateway version is higher than 0.92 (first version SG support gzip)
- request body is gzipped if json size is > 100 (client -> SG)
- response body is gzipped if json size is > 1000 (SG -> client)  note: this is SG side configuration.
- binary data is not gzipped
- Test is done manually by using ToDo Lite app (Create text > 100 for request test, create text > 1000 for response test)
- Unit test for Android was also updated to handle gzipped request.
