### PR TITLE
Fix #328

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -561,9 +561,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     }
 
     private void revisionFailed(RevisionInternal rev, Throwable throwable) {
-        if (Utils.isTransientError(throwable)) {
-            // retry later
-        } else {
+        if (!Utils.isTransientError(throwable)) {
             Log.v(Log.TAG_SYNC, "%s: giving up on %s: %s", this, rev, throwable);
             pendingSequences.removeSequence(rev.getSequence());
         }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -325,7 +325,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             // The entire _bulk_get is finished:
                             if (e != null) {
                                 setError(e);
-                                revisionFailed();
                                 completedChangesCount.addAndGet(remainingRevs.size());
                             }
 
@@ -427,7 +426,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
                         if (e != null) {
                             setError(e);
-                            revisionFailed();
 
                             // TODO: There is a known bug caused by the line below, which is
                             // TODO: causing testMockSinglePullCouchDb to fail when running on a Nexus5 device.
@@ -500,7 +498,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                 if (history.isEmpty() && rev.getGeneration() > 1) {
                     Log.w(Log.TAG_SYNC, "%s: Missing revision history in response for: %s", this, rev);
                     setError(new CouchbaseLiteException(Status.UPSTREAM_ERROR));
-                    revisionFailed();
                     continue;
                 }
 
@@ -514,7 +511,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         Log.i(Log.TAG_SYNC, "%s: Remote rev failed validation: %s", this, rev);
                     } else {
                         Log.w(Log.TAG_SYNC, "%s: failed to write %s: status=%s", this, rev, e.getCBLStatus().getCode());
-                        revisionFailed();
                         setError(new HttpResponseException(e.getCBLStatus().getCode(), null));
                         continue;
                     }
@@ -566,7 +562,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     private void revisionFailed(RevisionInternal rev, Throwable throwable) {
         if (Utils.isTransientError(throwable)) {
-            revisionFailed();  // retry later
+            // retry later
         } else {
             Log.v(Log.TAG_SYNC, "%s: giving up on %s: %s", this, rev, throwable);
             pendingSequences.removeSequence(rev.getSequence());

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -369,7 +369,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 Map<String, Object> results = (Map<String, Object>) response;
                 if (e != null) {
                     setError(e);
-                    revisionFailed();
                 }
                 else {
                     if (results.size() != 0) {
@@ -405,7 +404,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                                 properties = new HashMap<String, Object>(rev.getProperties());
                             } catch (CouchbaseLiteException e1) {
                                 Log.w(Log.TAG_SYNC, "%s Couldn't get local contents of %s", rev, PusherInternal.this);
-                                revisionFailed();
                                 continue;
                             }
 
@@ -524,7 +522,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 }
                 if (e != null) {
                     setError(e);
-                    revisionFailed();
                 } else {
                     Log.v(Log.TAG_SYNC, "%s: POSTed to _bulk_docs", PusherInternal.this);
                 }
@@ -633,7 +630,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                         } else {
                             Log.e(Log.TAG_SYNC, "Exception uploading multipart request", e);
                             setError(e);
-                            revisionFailed();
                         }
                     } else {
                         Log.v(Log.TAG_SYNC, "Uploaded multipart request.  Revision: %s", revision);
@@ -659,7 +655,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
         // Get the revision's properties:
         if (!db.inlineFollowingAttachmentsIn(rev)) {
             error = new CouchbaseLiteException(Status.BAD_ATTACHMENT);
-            revisionFailed();
             return;
         }
 
@@ -671,7 +666,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                     public void onCompletion(HttpResponse httpResponse, Object result, Throwable e) {
                         if (e != null) {
                             setError(e);
-                            revisionFailed();
                         } else {
                             Log.v(Log.TAG_SYNC, "%s: Sent %s (JSON), response=%s", this, rev, result);
                             removePending(rev);

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -287,7 +287,6 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                     Log.v(Log.TAG_SYNC, "*** %s: BEGIN processInbox (%d sequences)", this, inbox.size());
                     processInbox(new RevisionList(inbox));
                     Log.v(Log.TAG_SYNC, "*** %s: END processInbox (lastSequence=%s)", this, lastSequence);
-                    Log.v(Log.TAG_SYNC, "%s: batcher calling updateActive()", this);
                 } catch (Exception e) {
                     Log.e(Log.TAG_SYNC,"ERROR: processInbox failed: ",e);
                     throw new RuntimeException(e);
@@ -1234,7 +1233,6 @@ abstract class ReplicationInternal implements BlockingQueueListener{
     public void addToInbox(RevisionInternal rev) {
         Log.v(Log.TAG_SYNC, "%s: addToInbox() called, rev: %s.  Thread: %s", this, rev, Thread.currentThread());
         batcher.queueObject(rev);
-        Log.v(Log.TAG_SYNC, "%s: addToInbox() calling updateActive()", this);
     }
 
     /**


### PR DESCRIPTION
- To change the rule of sending PUT /{db}/_local/xxxx to follow iOS implementation
- Cleanup unused codes. By shifting to StateMachine, some variables and methods which are from iOS code were not used.