### PR TITLE
Fix #395 Fix HTTP header values for pull and push replication

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -68,6 +68,8 @@ public final class Manager {
 
     public static final String VERSION = Version.VERSION;
 
+    public static final String USER_AGENT = "CouchbaseLite/" + Version.getVersionName();
+
     private static final ObjectMapper mapper = new ObjectMapper();
     private ManagerOptions options;
     private File directoryFile;

--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -82,6 +82,7 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
         request.addHeader("Content-Type", "application/json");
         request.addHeader("Accept", "multipart/related");
         request.addHeader("X-Accept-Part-Encoding", "gzip");
+        request.addHeader("User-Agent", Manager.USER_AGENT);
         request.addHeader("Accept-Encoding", "gzip, deflate");
 
         addRequestHeaders(request);
@@ -174,12 +175,10 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                     if (entity != null) {
 
                         inputStream = entity.getContent();
-
                         // decompress if contentEncoding is gzip
                         if(Utils.isGzip(entity)){
                             inputStream = new GZIPInputStream(inputStream);
                         }
-
                         try {
                             fullBody = Manager.getObjectMapper().readValue(inputStream,
                                     Object.class);

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
@@ -42,6 +42,7 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
 
         request.addHeader("Accept", "multipart/related, application/json");
         request.addHeader("X-Accept-Part-Encoding", "gzip");
+        request.addHeader("User-Agent", Manager.USER_AGENT);
         request.addHeader("Accept-Encoding", "gzip, deflate");
 
         addRequestHeaders(request);
@@ -127,7 +128,6 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
                         if(contentEncoding != null && contentEncoding.getValue().contains("gzip")){
                             inputStream = new GZIPInputStream(inputStream);
                         }
-
                         try {
                             fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
                             respondWithResult(fullBody, error, response);


### PR DESCRIPTION
By missing "Accept-Encoding" request header for some requests, Sync Gateway sent uncompressed data to client. Fixed that issue. And also added User-Agent header. 

Test:
- Passed existing all unit test cases
- Passed performance test tools
- Passed manual testing with using ToDo Lite Sample

Note: No specific unit test case for this.