### PR TITLE
Fixed #242 - Nested transaction issue

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1228,7 +1228,7 @@ public final class Database {
             }
             // Inner (level 1 or higher) transaction. Use SQLite's SAVEPOINT
             else{
-                database.execSQL("SAVEPOINT tdb" + Integer.toString(transactionLevel));
+                database.execSQL("SAVEPOINT cbl_" + Integer.toString(transactionLevel));
             }
 
             Log.i(Log.TAG, "%s Begin transaction (level %d)", Thread.currentThread().getName(), transactionLevel);
@@ -1278,14 +1278,14 @@ public final class Database {
             } else {
                 Log.i(Log.TAG, "%s CANCEL transaction (level %d)", Thread.currentThread().getName(), transactionLevel);
                 try {
-                    database.execSQL(";ROLLBACK TO tdb" + Integer.toString(transactionLevel));
+                    database.execSQL(";ROLLBACK TO cbl_" + Integer.toString(transactionLevel));
                 } catch (SQLException e) {
                     Log.e(Database.TAG, Thread.currentThread().getName() + " Error calling endTransaction()", e);
                     return false;
                 }
             }
             try{
-                database.execSQL("RELEASE tdb" + Integer.toString(transactionLevel));
+                database.execSQL("RELEASE cbl_" + Integer.toString(transactionLevel));
             }
             catch (SQLException e) {
                 Log.e(Database.TAG, Thread.currentThread().getName() + " Error calling endTransaction()", e);

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1203,6 +1203,20 @@ public final class Database {
     /**
      * Begins a database transaction. Transactions can nest.
      * Every beginTransaction() must be balanced by a later endTransaction()
+     *
+     * Notes: 1. SQLiteDatabase.beginTransaction() supported nested transaction. But, in case
+     *           nested transaction rollbacked, it also rollbacks outer transaction too.
+     *           This is not ideal behavior for CBL
+     *        2. SAVEPOINT...RELEASE supports nested transaction. But Android API 14 and 15,
+     *           it throws Exception. I assume it is Android bug. As CBL need to support from API 10
+     *           . So it does not work for CBL.
+     *        3. Using Transaction for outer/1st level of transaction and inner/2nd level of transaction
+     *           works with CBL requirement.
+     *        4. CBL Android and Java uses Thread, So it is better to use SQLiteDatabase.beginTransaction()
+     *           for outer/1st level transaction. if we use BEGIN...COMMIT and SAVEPOINT...RELEASE,
+     *           we need to implement wrapper of BEGIN...COMMIT and SAVEPOINT...RELEASE to be
+     *           Thread-safe.
+     *
      * @exclude
      */
     @InterfaceAudience.Private


### PR DESCRIPTION
Reason behind this implementation
1. `SQLiteDatabase.beginTransaction()` supported nested transaction. But, in case, nested transaction rollbacked, it also rollbacks outer transaction too. This is not ideal behavior for CBL
2. `SAVEPOINT...RELEASE` supports nested transaction. But Android API 14 and 15, it throws Exception. I assume it is Android bug. As CBL need to support from API 10. So it does not work for CBL.
3. Using Transaction for outer/1st level of transaction and inner/2nd level of transaction works with CBL requirement.
4. CBL Android and Java uses Thread, So it is better to use `SQLiteDatabase.beginTransaction()` for outer/1st level transaction. if we use `BEGIN...COMMIT` and `SAVEPOINT...RELEASE`, we need to implement wrapper of `BEGIN...COMMIT` and `SAVEPOINT...RELEASE` to be Thread-safe.