### PR TITLE
Fix #415

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -591,12 +591,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         // attachments we already have locally:
         AtomicBoolean hasAttachment = new AtomicBoolean(false);
         List<String> knownRevs = db.getPossibleAncestorRevisionIDs(rev, PullerInternal.MAX_NUMBER_OF_ATTS_SINCE, hasAttachment);
-        if (knownRevs == null) {
-            Log.w(Log.TAG_SYNC, "knownRevs == null, something is wrong, possibly the replicator has shut down");
-            --httpConnectionCount;
-            return;
-        }
-        if (hasAttachment.get() && knownRevs.size() > 0) {
+        if (hasAttachment.get() && knownRevs != null && knownRevs.size() > 0) {
             path.append("&atts_since=");
             path.append(joinQuotedEscaped(knownRevs));
         }
@@ -645,16 +640,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         return URLEncoder.encode(new String(json));
     }
 
-
-    @InterfaceAudience.Private
-    /* package */
-    List<String> knownCurrentRevIDs(RevisionInternal rev) {
-        if (db != null) {
-            return db.getAllRevisionsOfDocumentID(rev.getDocId(), true).getAllRevIds();
-        }
-        return null;
-    }
-
     /**
      * Add a revision to the appropriate queue of revs to individually GET
      */
@@ -673,9 +658,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         }
     }
 
-
-
-
     private void initPendingSequences() {
 
         if (pendingSequences == null) {
@@ -685,7 +667,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                 long seq = pendingSequences.addValue(getLastSequence());
                 pendingSequences.removeSequence(seq);
                 assert (pendingSequences.getCheckpointedValue().equals(getLastSequence()));
-
             }
         }
     }


### PR DESCRIPTION
Fixed #415 Sync (pull replication) fails on document with a lot of re visions with conflicts and attachments

- Limits max revisions for atts_since parameter of /{db}/{docID}?... request. Actually apply same logic with iOS version.
- Update `Database.getPossibleAncestorRevisionIDs()` because of inconsistency with iOS version.