### PR TITLE
Fix router creating a wrong handler when getting /db/_session

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -411,6 +411,10 @@ public class Router implements Database.ChangeListener {
             } else if(name.startsWith("_design") || name.startsWith("_local")) {
                 // This is also a document, just with a URL-encoded "/"
                 docID = name;
+            } else if (name.equals("_session")) {
+                // There are two possible uri to get a session, /<db>/_session or /_session.
+                // This is for /<db>/_session.
+                message = message.replaceFirst("_Document", name);
             } else {
                 // Special document name like "_all_docs":
                 message += name;


### PR DESCRIPTION
There are two possible uri to get a session, /<db>/_session or /_session. The current code has already taken care  the /_session message. But when it got /<db>/_session, it was turn the message into do_GET_Document_session instead of do_GET_session.

#426