### PR TITLE
Fixed  #422 pull repl null attachment

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -4014,7 +4014,7 @@ public final class Database {
                     }
 
                     // Insert it:
-                    sequence = insertRevision(newRev, docNumericID, sequence, current, (newRev.getAttachments().size() > 0), data);
+                    sequence = insertRevision(newRev, docNumericID, sequence, current, (newRev.getAttachments() != null && newRev.getAttachments().size() > 0), data);
 
                     if(sequence <= 0) {
                         throw new CouchbaseLiteException(Status.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -2559,6 +2559,7 @@ public final class Database {
         if (digest == null) {
             throw new CouchbaseLiteException(Status.BAD_ATTACHMENT);
         }
+
         if (pendingAttachmentsByDigest != null && pendingAttachmentsByDigest.containsKey(digest)) {
             BlobStoreWriter writer = pendingAttachmentsByDigest.get(digest);
             try {
@@ -2569,6 +2570,10 @@ public final class Database {
             } catch (Exception e) {
                 throw new CouchbaseLiteException(e, Status.STATUS_ATTACHMENT_ERROR);
             }
+        }
+        else{
+            Log.w(Database.TAG, "No pending attachment for digest: " + digest);
+            throw new CouchbaseLiteException(Status.BAD_ATTACHMENT);
         }
     }
 


### PR DESCRIPTION
- Added throw CouchbaseLiteException in `installAttachment()` method in case that digest key is not in pendingAttachmentsByDigest.
- Add null check to avoid NPE

See: https://github.com/couchbase/couchbase-lite-java-core/issues/422#issuecomment-74183180