### PR TITLE
Fixed #357

### DIFF
--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -195,7 +195,7 @@ public class Batcher<T> {
                     T t = inbox.take();
                     toProcess.add(t);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Log.w(Log.TAG_BATCHER, "%s: processNow(): %s", this, e.getMessage());
                 }
             }
         } else {
@@ -206,7 +206,7 @@ public class Batcher<T> {
                     T t = inbox.take();
                     toProcess.add(t);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Log.w(Log.TAG_BATCHER, "%s: processNow(): %s", this, e.getMessage());
                 }
                 i += 1;
             }


### PR DESCRIPTION
- InterruptedException could be thrown, it should be ignored for this case. Replaced e.printStackTrace() with Log.w().
- No Unit Test for this. Just run BatcherTest.java