### PR TITLE
Fixed #434 - Should not show error message for failing to parse VERSION_...

### DIFF
--- a/src/main/java/com/couchbase/lite/support/Version.java
+++ b/src/main/java/com/couchbase/lite/support/Version.java
@@ -3,15 +3,14 @@ package com.couchbase.lite.support;
 import com.couchbase.lite.util.Log;
 
 public class Version {
-
     public static final String VERSION;
 
     private static final String VERSION_NAME="${VERSION_NAME}";  // replaced during build process
     private static final String VERSION_CODE="${VERSION_CODE}";  // replaced during build process
 
     static {
-        int versCode=getVersionCode();
-        if (versCode==-1) {
+        int versCode = getVersionCode();
+        if (versCode == -1) {
             VERSION = String.format("%s-%s", getVersionName(), getVersionCode());
         } else{
             VERSION = String.format("%s", getVersionName());
@@ -29,18 +28,22 @@ public class Version {
         if (VERSION_CODE == "${VERSION_CODE}") {
             return 0;
         }
+
+        // VERSION_CODE should be empty string if it is release build
+        if(VERSION_CODE == null || VERSION_CODE.isEmpty()) {
+            return 0;
+        }
+
         try {
             Integer.parseInt(VERSION_CODE);
         } catch (NumberFormatException e) {
-            Log.e(Log.TAG, "Cannot parse version code: %s", VERSION_CODE);
+            Log.w(Log.TAG, "Cannot parse version code: %s", VERSION_CODE);
+            return 0;
         }
         return -1;
     }
 
-
     public static String getVersion() {
-        return String.format("%s-%s", getVersionName(), getVersionCode());
+        return VERSION;
     }
-
-
 }


### PR DESCRIPTION
...CODE


According to build engineer, VERSION_CODE should be empty string for release build.

- should not show error message for failure of parsing VERSION_CODE
- minor refactoring