### PR TITLE
Fixed #441 - testOneTimePullReplicationSendStoppedOnce failed

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1171,6 +1171,15 @@ abstract class ReplicationInternal implements BlockingQueueListener{
             @Override
             public void doIt(Transition<ReplicationState, ReplicationTrigger> transition) {
                 Log.v(Log.TAG_SYNC, "[onEntry()] " + transition.getSource() + " => " + transition.getDestination());
+
+                // NOTE: Based on StateMachine configuration, this should not happen.
+                //       However, from Unit Test result, this could be happen.
+                //       We should revisit StateMachine configuration and also its Thread-safe-ability
+                if(transition.getSource() == transition.getDestination()) {
+                    // ignore STOPPING to STOPPING
+                    return;
+                }
+
                 ReplicationInternal.this.stopGraceful();
                 notifyChangeListenersStateTransition(transition);
             }
@@ -1182,6 +1191,9 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                 saveLastSequence(); // move from databaseClosing() method as databaseClosing() is not called if Rem
                 ReplicationInternal.this.clearDbRef();
 
+                // NOTE: Based on StateMachine configuration, this should not happen.
+                //       However, from Unit Test result, this could be happen.
+                //       We should revisit StateMachine configuration and also its Thread-safe-ability
                 if(transition.getSource() == transition.getDestination()) {
                     // ignore STOPPED to STOPPED
                     return;

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1181,6 +1181,11 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                 Log.v(Log.TAG_SYNC, "[onEntry()] " + transition.getSource() + " => " + transition.getDestination());
                 saveLastSequence(); // move from databaseClosing() method as databaseClosing() is not called if Rem
                 ReplicationInternal.this.clearDbRef();
+
+                if(transition.getSource() == transition.getDestination()) {
+                    // ignore STOPPED to STOPPED
+                    return;
+                }
                 notifyChangeListenersStateTransition(transition);
             }
         });


### PR DESCRIPTION
- Actually I could not reproduce this issue with my test environment. I assume potential issue was sending STOPPED event when replicator state was already STOPPED because of race condition.