### PR TITLE
Fixed #447 Make sure close every GZipInputStream instance after used.

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -173,19 +173,17 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                 else {
                     Log.v(Log.TAG_SYNC, "contentTypeHeader is not multipart = %s",contentTypeHeader.getValue());
                     if (entity != null) {
-
-                        inputStream = entity.getContent();
-                        // decompress if contentEncoding is gzip
-                        if(Utils.isGzip(entity)){
-                            inputStream = new GZIPInputStream(inputStream);
-                        }
                         try {
-                            fullBody = Manager.getObjectMapper().readValue(inputStream,
-                                    Object.class);
+                            inputStream = entity.getContent();
+                            // decompress if contentEncoding is gzip
+                            if(Utils.isGzip(entity)){
+                                inputStream = new GZIPInputStream(inputStream);
+                            }
+                            fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
                             respondWithResult(fullBody, error, response);
                         } finally {
                             try {
-                                inputStream.close();
+                                if(inputStream != null) { inputStream.close(); }
                             } catch (IOException e) {
                             }
                         }

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
@@ -121,19 +121,18 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
                 }
                 else {
                     if (entity != null) {
-                        inputStream = entity.getContent();
-
-                        // decompress if contentEncoding is gzip
-                        Header contentEncoding = entity.getContentEncoding();
-                        if(contentEncoding != null && contentEncoding.getValue().contains("gzip")){
-                            inputStream = new GZIPInputStream(inputStream);
-                        }
                         try {
+                            inputStream = entity.getContent();
+                            // decompress if contentEncoding is gzip
+                            Header contentEncoding = entity.getContentEncoding();
+                            if(contentEncoding != null && contentEncoding.getValue().contains("gzip")){
+                                inputStream = new GZIPInputStream(inputStream);
+                            }
                             fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
                             respondWithResult(fullBody, error, response);
                         } finally {
                             try {
-                                inputStream.close();
+                                if(inputStream != null){ inputStream.close(); }
                             } catch (IOException e) {
                             }
                         }

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -222,7 +222,7 @@ public class RemoteRequest implements Runnable {
                         fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
                     } finally {
                         try {
-                            inputStream.close();
+                            if(inputStream != null){ inputStream.close(); }
                         } catch (IOException e) {
                         }
                     }


### PR DESCRIPTION
Unclosed GZipInputStream might cause resource leak and might end up to cause out of memory issue.

By this fix, all GZipInputStram and GZipOutputStram are closed in finally block.