### PR TITLE
Fixed #449 - NullPointerException

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -259,9 +259,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         }
 
         for (RevisionInternal work : workToStartNow) {
-            if(work != null) {
-                pullRemoteRevision(work);
-            }
+            pullRemoteRevision(work);
         }
     }
 
@@ -579,7 +577,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     @InterfaceAudience.Private
     public void pullRemoteRevision(final RevisionInternal rev) {
 
-        if(rev == null) return;
+        if(rev == null){
+            Log.w(Log.TAG_SYNC, "rev is null.");
+            return;
+        }
 
         Log.d(Log.TAG_SYNC, "%s: pullRemoteRevision with rev: %s", this, rev);
 
@@ -649,6 +650,12 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
      */
     @InterfaceAudience.Private
     protected void queueRemoteRevision(RevisionInternal rev) {
+
+        if(rev == null){
+            Log.w(Log.TAG_SYNC, "rev is null.");
+            return;
+        }
+
         if (rev.isDeleted()) {
             if (deletedRevsToPull == null) {
                 deletedRevsToPull = new ArrayList<RevisionInternal>(100);

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -259,7 +259,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         }
 
         for (RevisionInternal work : workToStartNow) {
-            pullRemoteRevision(work);
+            if(work != null) {
+                pullRemoteRevision(work);
+            }
         }
     }
 
@@ -576,6 +578,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
      */
     @InterfaceAudience.Private
     public void pullRemoteRevision(final RevisionInternal rev) {
+
+        if(rev == null) return;
 
         Log.d(Log.TAG_SYNC, "%s: pullRemoteRevision with rev: %s", this, rev);
 


### PR DESCRIPTION
From customer's stack trace, null parameter was given to `pullRemoteRevision(final RevisionInternal rev)` method. This is just check if parameter is null.

From stack trace, it is hard to identify what root cause is. Require more information to solve the root cause.