### PR TITLE
Fixed #465 VERSION string generation for dev build is not correct

### DIFF
--- a/src/main/java/com/couchbase/lite/support/Version.java
+++ b/src/main/java/com/couchbase/lite/support/Version.java
@@ -11,7 +11,7 @@ public class Version {
     static {
         int versCode = getVersionCode();
         if (versCode == -1) {
-            VERSION = String.format("%s-%s", getVersionName(), getVersionCode());
+            VERSION = String.format("%s-%s", getVersionName(), getVersion());
         } else{
             VERSION = String.format("%s", getVersionName());
         }


### PR DESCRIPTION
- Actual fix was done with release/1.0.4 branch.
- VERSION string generation for dev build is wrong. This commit fix this.