### PR TITLE
Fixed #447 Improve memory usage during pull replication

### DIFF
--- a/src/main/java/com/couchbase/lite/BlobStoreWriter.java
+++ b/src/main/java/com/couchbase/lite/BlobStoreWriter.java
@@ -19,27 +19,27 @@ import java.security.NoSuchAlgorithmException;
 public class BlobStoreWriter {
 
     /** The underlying blob store where it should be stored. */
-    private BlobStore store;
+    private BlobStore store =  null;
 
     /** The number of bytes in the blob. */
-    private int length;
+    private int length = 0;
 
     /** After finishing, this is the key for looking up the blob through the CBL_BlobStore. */
-    private BlobKey blobKey;
+    private BlobKey blobKey =  null;
 
     /** After finishing, store md5 digest result here */
-    private byte[] md5DigestResult;
+    private byte[] md5DigestResult =  null;
 
     /** Message digest for sha1 that is updated as data is appended */
-    private MessageDigest sha1Digest;
-    private MessageDigest md5Digest;
+    private MessageDigest sha1Digest =  null;
+    private MessageDigest md5Digest =  null;
 
-    private BufferedOutputStream outStream;
-    private File tempFile;
+    //private FileOutputStream     fos = null;
+    private BufferedOutputStream outStream = null;
+    private File tempFile =  null;
 
     public BlobStoreWriter(BlobStore store) {
         this.store = store;
-
         try {
             sha1Digest = MessageDigest.getInstance("SHA-1");
             sha1Digest.reset();
@@ -48,29 +48,27 @@ public class BlobStoreWriter {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }
-
         try {
             openTempFile();
         } catch (FileNotFoundException e) {
             throw new IllegalStateException(e);
         }
-
     }
 
-    private void openTempFile() throws FileNotFoundException {
-
+    private void openTempFile() throws FileNotFoundException
+    {
         String uuid = Misc.TDCreateUUID();
         String filename = String.format("%s.blobtmp", uuid);
         File tempDir = store.tempDir();
         tempFile = new File(tempDir, filename);
         outStream = new BufferedOutputStream(new FileOutputStream(tempFile));
-
     }
 
     /** Appends data to the blob. Call this when new data is available. */
     public void appendData(byte[] data)  {
         appendData(data, 0, data.length);
     }
+
     public void appendData(final byte[] data, int off, int len)  {
         try {
             outStream.write(data, off, len);
@@ -98,6 +96,7 @@ public class BlobStoreWriter {
         } finally {
             try {
                 inputStream.close();
+                inputStream = null;
             } catch (IOException e) {
                 Log.w(Log.TAG_BLOB_STORE, "Exception closing input stream", e);
             }
@@ -107,9 +106,13 @@ public class BlobStoreWriter {
     /** Call this after all the data has been added. */
     public void finish() {
         try {
-            outStream.close();
+            if(outStream != null) {
+                // FileOutputStream is also closed cascadingly
+                outStream.close();
+                outStream = null;
+            }
         } catch (IOException e) {
-            Log.w(Log.TAG_BLOB_STORE, "Exception closing output stream", e);
+            Log.w(Log.TAG_BLOB_STORE, "Exception closing buffered output stream", e);
         }
         blobKey = new BlobKey(sha1Digest.digest());
         md5DigestResult = md5Digest.digest();
@@ -118,16 +121,20 @@ public class BlobStoreWriter {
     /** Call this to cancel before finishing the data. */
     public void cancel() {
         try {
-            outStream.close();
+            // FileOutputStream is also closed cascadingly
+            if(outStream != null) {
+                outStream.close();
+                outStream = null;
+            }
         } catch (IOException e) {
-            Log.w(Log.TAG_BLOB_STORE, "Exception closing output stream", e);
+            Log.w(Log.TAG_BLOB_STORE, "Exception closing buffered output stream", e);
         }
         tempFile.delete();
     }
 
     /** Installs a finished blob into the store. */
-    public void install() {
-
+    public void install()
+    {
         if (tempFile == null) {
             return;  // already installed
         }
@@ -144,7 +151,6 @@ public class BlobStoreWriter {
         }
 
         tempFile = null;
-
     }
 
     public String mD5DigestString() {

--- a/src/main/java/com/couchbase/lite/BlobStoreWriter.java
+++ b/src/main/java/com/couchbase/lite/BlobStoreWriter.java
@@ -34,9 +34,8 @@ public class BlobStoreWriter {
     private MessageDigest sha1Digest =  null;
     private MessageDigest md5Digest =  null;
 
-    //private FileOutputStream     fos = null;
     private BufferedOutputStream outStream = null;
-    private File tempFile =  null;
+    private File tempFile = null;
 
     public BlobStoreWriter(BlobStore store) {
         this.store = store;
@@ -55,8 +54,7 @@ public class BlobStoreWriter {
         }
     }
 
-    private void openTempFile() throws FileNotFoundException
-    {
+    private void openTempFile() throws FileNotFoundException {
         String uuid = Misc.TDCreateUUID();
         String filename = String.format("%s.blobtmp", uuid);
         File tempDir = store.tempDir();

--- a/src/main/java/com/couchbase/lite/BlobStoreWriter.java
+++ b/src/main/java/com/couchbase/lite/BlobStoreWriter.java
@@ -69,14 +69,17 @@ public class BlobStoreWriter {
 
     /** Appends data to the blob. Call this when new data is available. */
     public void appendData(byte[] data)  {
+        appendData(data, 0, data.length);
+    }
+    public void appendData(final byte[] data, int off, int len)  {
         try {
-            outStream.write(data);
+            outStream.write(data, off, len);
         } catch (IOException e) {
             throw new RuntimeException("Unable to write to stream.", e);
         }
-        length += data.length;
-        sha1Digest.update(data);
-        md5Digest.update(data);
+        length += len;
+        sha1Digest.update(data, off, len);
+        md5Digest.update(data, off, len);
     }
 
     void read(InputStream inputStream) {

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -489,7 +489,7 @@ public final class Database {
         if (properties == null) {
             deleted = true;
         }
-        RevisionInternal rev = new RevisionInternal(id, null, deleted, this);
+        RevisionInternal rev = new RevisionInternal(id, null, deleted);
 
         if (properties != null) {
             rev.setProperties(properties);
@@ -1495,7 +1495,7 @@ public final class Database {
     @InterfaceAudience.Private
     public Map<String, Object> documentPropertiesFromJSON(byte[] json, String docId, String revId, boolean deleted, long sequence, EnumSet<TDContentOptions> contentOptions) {
 
-        RevisionInternal rev = new RevisionInternal(docId, revId, deleted, this);
+        RevisionInternal rev = new RevisionInternal(docId, revId, deleted);
         rev.setSequence(sequence);
         Map<String, Object> extra = extraPropertiesForRevision(rev, contentOptions);
         if (json == null) {
@@ -1547,7 +1547,7 @@ public final class Database {
                     rev = cursor.getString(0);
                 }
                 boolean deleted = (cursor.getInt(1) > 0);
-                result = new RevisionInternal(id, rev, deleted, this);
+                result = new RevisionInternal(id, rev, deleted);
                 result.setSequence(cursor.getLong(2));
                 if(!contentOptions.equals(EnumSet.of(TDContentOptions.TDNoBody))) {
                     byte[] json = null;
@@ -1678,7 +1678,7 @@ public final class Database {
             cursor.moveToNext();
             result = new RevisionList();
             while(!cursor.isAfterLast()) {
-                RevisionInternal rev = new RevisionInternal(docId, cursor.getString(1), (cursor.getInt(2) > 0), this);
+                RevisionInternal rev = new RevisionInternal(docId, cursor.getString(1), (cursor.getInt(2) > 0));
                 rev.setSequence(cursor.getLong(0));
                 result.add(rev);
                 cursor.moveToNext();
@@ -1871,7 +1871,7 @@ public final class Database {
                     revId = cursor.getString(2);
                     boolean deleted = (cursor.getInt(3) > 0);
                     boolean missing = (cursor.getInt(4) > 0);
-                    RevisionInternal aRev = new RevisionInternal(docId, revId, deleted, this);
+                    RevisionInternal aRev = new RevisionInternal(docId, revId, deleted);
                     aRev.setMissing(missing);
                     aRev.setSequence(cursor.getLong(0));
                     result.add(aRev);
@@ -2043,7 +2043,7 @@ public final class Database {
                     lastDocId = docNumericId;
                 }
 
-                RevisionInternal rev = new RevisionInternal(cursor.getString(2), cursor.getString(3), (cursor.getInt(4) > 0), this);
+                RevisionInternal rev = new RevisionInternal(cursor.getString(2), cursor.getString(3), (cursor.getInt(4) > 0));
                 rev.setSequence(cursor.getLong(0));
                 if(includeDocs) {
                     expandStoredJSONIntoRevisionWithAttachments(cursor.getBlob(5), rev, options.getContentOptions());
@@ -3063,7 +3063,7 @@ public final class Database {
 
         beginTransaction();
         try {
-            RevisionInternal oldRev = new RevisionInternal(docID, oldRevID, false, this);
+            RevisionInternal oldRev = new RevisionInternal(docID, oldRevID, false);
             if(oldRevID != null) {
 
                 // Load existing revision if this is a replacement:
@@ -3599,7 +3599,7 @@ public final class Database {
                 if(validations != null && validations.size() > 0) {
                     // Fetch the previous revision and validate the new one against it:
                     RevisionInternal fakeNewRev = oldRev.copyWithDocID(oldRev.getDocId(), null);
-                    RevisionInternal prevRev = new RevisionInternal(docId, prevRevId, false, this);
+                    RevisionInternal prevRev = new RevisionInternal(docId, prevRevId, false);
                     validateRevision(fakeNewRev, prevRev,prevRevId);
                 }
 
@@ -3796,7 +3796,7 @@ public final class Database {
                     return newRev;
                 } else {
                     boolean deleted = false;
-                    RevisionInternal winningRev = new RevisionInternal(newRev.getDocId(), winningRevID, deleted, this);
+                    RevisionInternal winningRev = new RevisionInternal(newRev.getDocId(), winningRevID, deleted);
                     return winningRev;
                 }
             }
@@ -4022,7 +4022,7 @@ public final class Database {
                     }
                     else {
                         // It's an intermediate parent, so insert a stub:
-                        newRev = new RevisionInternal(docId, revId, false, this);
+                        newRev = new RevisionInternal(docId, revId, false);
                     }
 
                     // Insert it:
@@ -4442,7 +4442,7 @@ public final class Database {
             if (cursor.moveToNext()) {
                 String revId = cursor.getString(0);
                 boolean deleted = (cursor.getInt(1) > 0);
-                result = new RevisionInternal(rev.getDocId(), revId, deleted, this);
+                result = new RevisionInternal(rev.getDocId(), revId, deleted/*, this*/);
                 result.setSequence(seq);
             }
         } finally {
@@ -4629,7 +4629,7 @@ public final class Database {
                     properties = Manager.getObjectMapper().readValue(json, Map.class);
                     properties.put("_id", docID);
                     properties.put("_rev", gotRevID);
-                    result = new RevisionInternal(docID, gotRevID, false, this);
+                    result = new RevisionInternal(docID, gotRevID, false);
                     result.setProperties(properties);
                 } catch (Exception e) {
                     Log.w(Database.TAG, "Error parsing local doc JSON", e);

--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -410,7 +410,7 @@ public class Document {
             hasTrueDeletedProperty = properties.get("_deleted") != null && ((Boolean)properties.get("_deleted")).booleanValue();
         }
         boolean deleted = (properties == null) || hasTrueDeletedProperty;
-        RevisionInternal rev = new RevisionInternal(documentId, null, deleted, database);
+        RevisionInternal rev = new RevisionInternal(documentId, null, deleted);
         if (properties != null) {
             rev.setProperties(properties);
         }
@@ -466,7 +466,7 @@ public class Document {
         if (currentRevision == null || revIdGreaterThanCurrent(revId)) {
             Map<String, Object> properties = row.getDocumentProperties();
             if (properties != null) {
-                RevisionInternal rev = new RevisionInternal(properties, row.getDatabase());
+                RevisionInternal rev = new RevisionInternal(properties);
                 currentRevision = new SavedRevision(this, rev);
             }
         }

--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -70,7 +70,6 @@ public final class Manager {
 
     public static final String USER_AGENT = "CouchbaseLite/" + Version.getVersionName();
 
-    private static final ObjectMapper mapper = new ObjectMapper();
     private ManagerOptions options;
     private File directoryFile;
     private Map<String, Database> databases;
@@ -84,7 +83,7 @@ public final class Manager {
      */
     @InterfaceAudience.Private
     public static ObjectMapper getObjectMapper() {
-        return mapper;
+        return new ObjectMapper();
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/Revision.java
+++ b/src/main/java/com/couchbase/lite/Revision.java
@@ -33,11 +33,6 @@ public abstract class Revision {
     protected String parentRevID;
 
     /**
-     * The revision this one is a child of.
-     */
-    protected SavedRevision parentRevision;
-
-    /**
      * Constructor
      * @exclude
      */
@@ -215,7 +210,7 @@ public abstract class Revision {
      * Compare this revision to the given revision to check for equality.
      * The comparison makes sure that both revisions have the same revision ID.
      *
-     * @param the revision to check for equality against
+     * @param o the revision to check for equality against
      * @return true if equal, false otherwise
      */
     @Override

--- a/src/main/java/com/couchbase/lite/SavedRevision.java
+++ b/src/main/java/com/couchbase/lite/SavedRevision.java
@@ -198,10 +198,7 @@ public final class SavedRevision extends Revision {
         } catch (CouchbaseLiteException e) {
             throw new RuntimeException(e);
         }
-
     }
-
-
 }
 
 

--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * A request/response/document body, stored as either JSON or a Map<String,Object>
  */
-public class Body{
+public class Body {
     private byte[] json;
     private Object object;
 
@@ -43,7 +43,7 @@ public class Body{
         this.object = array;
     }
 
-    public static Body bodyWithProperties(Map<String,Object> properties) {
+    public static Body bodyWithProperties(Map<String, Object> properties) {
         Body result = new Body(properties);
         return result;
     }
@@ -105,7 +105,7 @@ public class Body{
 
     public byte[] getPrettyJson() {
         Object properties = getObject();
-        if(properties != null) {
+        if (properties != null) {
             ObjectWriter writer = Manager.getObjectMapper().writerWithDefaultPrettyPrinter();
             try {
                 json = writer.writeValueAsBytes(properties);
@@ -123,33 +123,32 @@ public class Body{
     @SuppressWarnings("unchecked")
     public Map<String, Object> getProperties() {
         Object object = getObject();
-        if(object instanceof Map) {
+        if (object instanceof Map) {
             // NOTE: Recreating new Map is not memory efficient. And iOS also does not do.
-            //return Collections.unmodifiableMap(map);
             return (Map<String, Object>) object;
         }
         return null;
     }
 
     public Object getPropertyForKey(String key) {
-        Map<String,Object> theProperties = getProperties();
+        Map<String, Object> theProperties = getProperties();
         if (theProperties == null) {
             return null;
         }
         return theProperties.get(key);
     }
 
-    public boolean compact(){
+    public boolean compact() {
         try {
             getJson();
-        }catch (RuntimeException re){
+        } catch (RuntimeException re) {
             return false;
         }
         this.object = null;
         return true;
     }
 
-    public void release(){
+    public void release() {
         this.object = null;
         this.json = null;
     }

--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -27,8 +27,7 @@ import java.util.Map;
 /**
  * A request/response/document body, stored as either JSON or a Map<String,Object>
  */
-public class Body
-{
+public class Body{
     private byte[] json;
     private Object object;
 
@@ -148,5 +147,10 @@ public class Body
         }
         this.object = null;
         return true;
+    }
+
+    public void release(){
+        this.object = null;
+        this.json = null;
     }
 }

--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -28,8 +28,8 @@ import java.util.Map;
 /**
  * A request/response/document body, stored as either JSON or a Map<String,Object>
  */
-public class Body {
-
+public class Body
+{
     private byte[] json;
     private Object object;
 
@@ -140,4 +140,13 @@ public class Body {
         return theProperties.get(key);
     }
 
+    public boolean compact(){
+        try {
+            getJson();
+        }catch (RuntimeException re){
+            return false;
+        }
+        this.object = null;
+        return true;
+    }
 }

--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -21,7 +21,6 @@ import com.couchbase.lite.Manager;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -126,8 +125,9 @@ public class Body
     public Map<String, Object> getProperties() {
         Object object = getObject();
         if(object instanceof Map) {
-            Map<String, Object> map = (Map<String, Object>) object;
-            return Collections.unmodifiableMap(map);
+            // NOTE: Recreating new Map is not memory efficient. And iOS also does not do.
+            //return Collections.unmodifiableMap(map);
+            return (Map<String, Object>) object;
         }
         return null;
     }

--- a/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
@@ -17,7 +17,6 @@
 
 package com.couchbase.lite.internal;
 
-import com.couchbase.lite.Database;
 import com.couchbase.lite.util.CollectionUtils;
 
 import java.util.HashMap;
@@ -37,25 +36,23 @@ public class RevisionInternal {
     private boolean missing;
     private Body body;
     private long sequence;
-    private Database database;  // TODO: get rid of this field!
 
-    public RevisionInternal(String docId, String revId, boolean deleted, Database database) {
+    public RevisionInternal(String docId, String revId, boolean deleted) {
         this.docId = docId;
         this.revId = revId;
         this.deleted = deleted;
-        this.database = database;
     }
 
-    public RevisionInternal(Body body, Database database) {
+    public RevisionInternal(Body body) {
         this((String) body.getPropertyForKey("_id"),
                 (String) body.getPropertyForKey("_rev"),
                 (((Boolean) body.getPropertyForKey("_deleted") != null)
-                        && ((Boolean) body.getPropertyForKey("_deleted") == true)), database);
+                        && ((Boolean) body.getPropertyForKey("_deleted") == true)));
         this.body = body;
     }
 
-    public RevisionInternal(Map<String, Object> properties, Database database) {
-        this(new Body(properties), database);
+    public RevisionInternal(Map<String, Object> properties) {
+        this(new Body(properties));
     }
 
     public Map<String, Object> getProperties() {
@@ -161,7 +158,7 @@ public class RevisionInternal {
         //assert((docId != null) && (revId != null));
         assert (docId != null);
         assert ((this.docId == null) || (this.docId.equals(docId)));
-        RevisionInternal result = new RevisionInternal(docId, revId, deleted, database);
+        RevisionInternal result = new RevisionInternal(docId, revId, deleted);
         Map<String, Object> unmodifiableProperties = getProperties();
         Map<String, Object> properties = new HashMap<String, Object>();
         if (unmodifiableProperties != null) {
@@ -313,5 +310,4 @@ public class RevisionInternal {
         }
         return new HashMap<String, Object>();
     }
-
 }

--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -202,7 +202,7 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
         }
         Log.v(Log.TAG_SYNC, "%s: Starting new document; headers =%s", this, headers);
         Log.v(Log.TAG_SYNC, "%s: Starting new document; ID=%s", this, headers.get("X-Doc-Id"));
-        _docReader = new MultipartDocumentReader(null, _db);
+        _docReader = new MultipartDocumentReader(_db);
         _docReader.setHeaders(headers);
         _docReader.startedPart(headers);
     }

--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -212,12 +212,15 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
      */
 
     public void appendToPart(byte[] data) {
+        appendToPart(data, 0, data.length);
+    }
+
+    public void appendToPart(final byte[] data, int off, int len) {
         if (_docReader == null) {
             throw new IllegalStateException("_docReader is not defined");
         }
-        _docReader.appendData(data);
+        _docReader.appendData(data, off, len);
     }
-
     /**
      * This method is called when a part is complete.
      */

--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -112,7 +112,7 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
             try {
                 // add in cookies to global store
                 if (httpClient instanceof DefaultHttpClient) {
-                    DefaultHttpClient defaultHttpClient = (DefaultHttpClient)httpClient;
+                    DefaultHttpClient defaultHttpClient = (DefaultHttpClient) httpClient;
                     clientFactory.addCookies(defaultHttpClient.getCookieStore().getCookies());
                 }
             } catch (Exception e) {
@@ -156,25 +156,38 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                                         if (Utils.isGzip(entity)) {
                                             gzipStream = new GZIPInputStream(inputStream);
                                             fullBody = Manager.getObjectMapper().readValue(gzipStream, Object.class);
-                                        }
-                                        else {
+                                        } else {
                                             fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
                                         }
                                         respondWithResult(fullBody, error, response);
                                     } finally {
-                                        try { if (gzipStream != null) { gzipStream.close(); } } catch (IOException e) { }
+                                        try {
+                                            if (gzipStream != null) {
+                                                gzipStream.close();
+                                            }
+                                        } catch (IOException e) {
+                                        }
                                         gzipStream = null;
                                     }
                                 }
                             }
-                        }finally{
-                            try { if (inputStream != null) { inputStream.close(); } } catch (IOException e) { }
+                        } finally {
+                            try {
+                                if (inputStream != null) {
+                                    inputStream.close();
+                                }
+                            } catch (IOException e) {
+                            }
                             inputStream = null;
                         }
                     }
-                }
-                finally{
-                    if(entity != null){try{ entity.consumeContent(); }catch (IOException e){}}
+                } finally {
+                    if (entity != null) {
+                        try {
+                            entity.consumeContent();
+                        } catch (IOException e) {
+                        }
+                    }
                     entity = null;
                 }
             }

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -342,8 +342,6 @@ public class ChangeTracker implements Runnable {
                             boolean responseOK = false; // default value
                             // check content length, ObjectMapper().readValue() throws Exception if size is 0.
                             if(entity.getContentLength() > 0) {
-                                // wait if paused flag is on.
-                                waitIfPaused();
                                 Log.v(Log.TAG_CHANGE_TRACKER, "%s: readValue", this);
                                 Map<String, Object> fullBody = Manager.getObjectMapper().readValue(inputStream, Map.class);
                                 Log.v(Log.TAG_CHANGE_TRACKER, "%s: /readValue.  fullBody: %s", this, fullBody);
@@ -375,8 +373,6 @@ public class ChangeTracker implements Runnable {
                             }
 
                             while (jp.nextToken() == JsonToken.START_OBJECT) {
-                                // wait if paused flag is on.
-                                waitIfPaused();
                                 Map<String, Object> change = (Map) Manager.getObjectMapper().readValue(jp, Map.class);
                                 if (!receivedChange(change)) {
                                     Log.w(Log.TAG_CHANGE_TRACKER, "Received unparseable change line from server: %s", change);
@@ -426,6 +422,9 @@ public class ChangeTracker implements Runnable {
     }
 
     public boolean receivedChange(final Map<String,Object> change) {
+        // wait if paused flag is on.
+        waitIfPaused();
+
         Object seq = change.get("seq");
         if(seq == null) {
             return false;
@@ -585,7 +584,7 @@ public class ChangeTracker implements Runnable {
 
 
     public void setPaused(boolean paused) {
-        Log.e(Log.TAG, "setPaused: " + paused);
+        Log.v(Log.TAG, "setPaused: " + paused);
         synchronized (pausedObj) {
             this.paused = paused;
             pausedObj.notifyAll();
@@ -594,7 +593,7 @@ public class ChangeTracker implements Runnable {
 
     protected void waitIfPaused(){
         while (paused) {
-            Log.e(Log.TAG, "Waiting: " + paused);
+            Log.v(Log.TAG, "Waiting: " + paused);
             synchronized (pausedObj) {
                 try {
                     pausedObj.wait();

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -218,10 +218,9 @@ public class ChangeTracker implements Runnable {
     @Override
     public void run() {
         Log.e(Log.TAG_CHANGE_TRACKER, "Thread id => " + Thread.currentThread().getId());
-        try{
+        try {
             runLoop();
-        }
-        finally{
+        } finally {
             // stopped() method should be called at end of run() method.
             stopped();
         }
@@ -292,8 +291,8 @@ public class ChangeTracker implements Runnable {
             if (userInfo != null) {
                 if (userInfo.contains(":") && !userInfo.trim().equals(":")) {
                     String[] userInfoElements = userInfo.split(":");
-                    String username = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[0]): userInfoElements[0];
-                    String password = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[1]): userInfoElements[1];
+                    String username = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[0]) : userInfoElements[0];
+                    String password = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[1]) : userInfoElements[1];
                     final Credentials credentials = new UsernamePasswordCredentials(username, password);
 
                     if (httpClient instanceof DefaultHttpClient) {
@@ -331,9 +330,6 @@ public class ChangeTracker implements Runnable {
                 HttpEntity entity = response.getEntity();
                 Log.v(Log.TAG_CHANGE_TRACKER, "%s: got response. status: %s mode: %s", this, status, mode);
                 if (entity != null) {
-
-
-
                     InputStream inputStream = null;
                     try {
                         Log.v(Log.TAG_CHANGE_TRACKER, "%s: /entity.getContent().  mode: %s", this, mode);
@@ -341,7 +337,7 @@ public class ChangeTracker implements Runnable {
                         if (mode == ChangeTrackerMode.LongPoll) {  // continuous replications
                             boolean responseOK = false; // default value
                             // check content length, ObjectMapper().readValue() throws Exception if size is 0.
-                            if(entity.getContentLength() > 0) {
+                            if (entity.getContentLength() > 0) {
                                 Log.v(Log.TAG_CHANGE_TRACKER, "%s: readValue", this);
                                 Map<String, Object> fullBody = Manager.getObjectMapper().readValue(inputStream, Map.class);
                                 Log.v(Log.TAG_CHANGE_TRACKER, "%s: /readValue.  fullBody: %s", this, fullBody);
@@ -366,7 +362,7 @@ public class ChangeTracker implements Runnable {
                         } else {  // one-shot replications
 
                             Log.v(Log.TAG_CHANGE_TRACKER, "%s: readValue (oneshot)", this);
-                            JsonFactory factory=new JsonFactory();
+                            JsonFactory factory = new JsonFactory();
                             JsonParser jp = factory.createParser(inputStream);
                             while (jp.nextToken() != JsonToken.START_ARRAY) {
                                 // ignore these tokens
@@ -379,7 +375,7 @@ public class ChangeTracker implements Runnable {
                                 }
                             }
 
-                            if(jp != null){
+                            if (jp != null) {
                                 jp.close();
                                 jp = null;
                             }
@@ -399,9 +395,19 @@ public class ChangeTracker implements Runnable {
 
                         backoff.resetBackoff();
                     } finally {
-                        try { if (inputStream != null) { inputStream.close(); } } catch (IOException e) { }
+                        try {
+                            if (inputStream != null) {
+                                inputStream.close();
+                            }
+                        } catch (IOException e) {
+                        }
                         inputStream = null;
-                        if(entity != null){try{ entity.consumeContent(); }catch (IOException e){}}
+                        if (entity != null) {
+                            try {
+                                entity.consumeContent();
+                            } catch (IOException e) {
+                            }
+                        }
                         entity = null;
                     }
                 }

--- a/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
+++ b/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
@@ -14,15 +14,15 @@ import java.util.Map;
 class PulledRevision extends RevisionInternal {
 
     public PulledRevision(Body body, Database database) {
-        super(body, database);
+        super(body);
     }
 
     public PulledRevision(String docId, String revId, boolean deleted, Database database) {
-        super(docId, revId, deleted, database);
+        super(docId, revId, deleted);
     }
 
     public PulledRevision(Map<String, Object> properties, Database database) {
-        super(properties, database);
+        super(properties);
     }
 
     protected String remoteSequenceID;

--- a/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
+++ b/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
@@ -1,6 +1,5 @@
 package com.couchbase.lite.replicator;
 
-import com.couchbase.lite.Database;
 import com.couchbase.lite.internal.Body;
 import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.internal.RevisionInternal;
@@ -13,15 +12,15 @@ import java.util.Map;
 @InterfaceAudience.Private
 class PulledRevision extends RevisionInternal {
 
-    public PulledRevision(Body body, Database database) {
+    public PulledRevision(Body body) {
         super(body);
     }
 
-    public PulledRevision(String docId, String revId, boolean deleted, Database database) {
+    public PulledRevision(String docId, String revId, boolean deleted) {
         super(docId, revId, deleted);
     }
 
-    public PulledRevision(Map<String, Object> properties, Database database) {
+    public PulledRevision(Map<String, Object> properties) {
         super(properties);
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -72,8 +72,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     /**
      * Actual work of starting the replication process.
      */
-    protected void beginReplicating() {
-
+    protected void beginReplicating()
+    {
         Log.d(Log.TAG_SYNC, "startReplicating()");
 
         initPendingSequences();
@@ -83,7 +83,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         startChangeTracker();
 
         // start replicator ..
-
     }
 
     private void initDownloadsToInsert() {
@@ -98,8 +97,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             });
         }
     }
-
-
 
     public boolean isPull() {
         return true;
@@ -134,7 +131,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
         changeTracker.setUsePOST(serverIsSyncGatewayVersion("0.93"));
         changeTracker.start();
-
     }
 
     /**
@@ -142,8 +138,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
      */
     @Override
     @InterfaceAudience.Private
-    protected void processInbox(RevisionList inbox) {
-
+    protected void processInbox(RevisionList inbox)
+    {
         Log.d(Log.TAG_SYNC, "processInbox called");
 
         if (canBulkGet == null) {
@@ -188,7 +184,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         Log.v(Log.TAG_SYNC, "%s: fetching %s remote revisions...", this, inboxCount);
 
         // Dump the revs into the queue of revs to pull from the remote db:
-        int numBulked = 0;
 
         for (int i = 0; i < inbox.size(); i++) {
 
@@ -202,9 +197,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     bulkRevsToPull = new ArrayList<RevisionInternal>(100);
 
                 bulkRevsToPull.add(rev);
-
-                ++numBulked;
-            } else {
+            }
+            else {
                 queueRemoteRevision(rev);
             }
 
@@ -298,9 +292,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             // Find the matching revision in 'remainingRevs' and get its sequence:
                             RevisionInternal rev;
                             if (props.get("_id") != null) {
-                                rev = new RevisionInternal(props, db);
+                                rev = new RevisionInternal(props);
                             } else {
-                                rev = new RevisionInternal((String) props.get("id"), (String) props.get("rev"), false, db);
+                                rev = new RevisionInternal((String) props.get("id"), (String) props.get("rev"), false);
                             }
 
                             int pos = remainingRevs.indexOf(rev);
@@ -441,7 +435,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             for (Map<String, Object> row : rows) {
                                 Map<String, Object> doc = (Map<String, Object>) row.get("doc");
                                 if (doc != null && doc.get("_attachments") == null) {
-                                    RevisionInternal rev = new RevisionInternal(doc, db);
+                                    RevisionInternal rev = new RevisionInternal(doc);
                                     RevisionInternal removedRev = remainingRevs.removeAndReturnRev(rev);
                                     if (removedRev != null) {
                                         rev.setSequence(removedRev.getSequence());
@@ -605,7 +599,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     gotRev.setSequence(rev.getSequence());
                     // Add to batcher ... eventually it will be fed to -insertDownloads:.
 
-                    // TODO: [gotRev.body compact];
                     if(gotRev.getBody() != null)
                         gotRev.getBody().compact();
                     Log.d(Log.TAG_SYNC, "%s: pullRemoteRevision add rev: %s to batcher: %s", PullerInternal.this, gotRev, downloadsToInsert);
@@ -731,19 +724,16 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             addToChangesCount(1);
 
             addToInbox(rev);
-
         }
-
-
-
     }
 
     @Override
-    public void changeTrackerStopped(ChangeTracker tracker) {
-
+    public void changeTrackerStopped(ChangeTracker tracker)
+    {
         // this callback will be on the changetracker thread, but we need
         // to do the work on the replicator thread.
-        workExecutor.submit(new Runnable() {
+        workExecutor.submit(new Runnable()
+        {
             @Override
             public void run() {
                 try {
@@ -754,7 +744,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                 }
             }
         });
-
     }
 
     private void processChangeTrackerStopped(ChangeTracker tracker) {
@@ -780,7 +769,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     parentReplication.setLastError(new Exception(msg));
                     fireTrigger(ReplicationTrigger.WAITING_FOR_CHANGES);
 
-
                     Log.d(Log.TAG_SYNC, "Scheduling change tracker restart in %d ms", CHANGE_TRACKER_RESTART_DELAY_MS);
                     workExecutor.schedule(new Runnable() {
                         @Override
@@ -796,8 +784,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         }
                     }, CHANGE_TRACKER_RESTART_DELAY_MS, TimeUnit.MILLISECONDS);
                 }
-
-
                 break;
             default:
                 throw new RuntimeException(String.format("Unknown lifecycle: %s", lifecycle));
@@ -896,29 +882,23 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         Log.d(Log.TAG_SYNC, "stopping change tracker");
                         changeTracker.stop();
                         Log.d(Log.TAG_SYNC, "stopped change tracker");
-
                     }
 
-                } catch (Exception e) {
+                }
+                catch (Exception e) {
                     Log.e(Log.TAG_SYNC, "stopGraceful.run() had exception: %s", e);
                     e.printStackTrace();
-
-                } finally {
-
+                }
+                finally {
                     triggerStopImmediate();
                 }
 
                 Log.e(Log.TAG_SYNC, "PullerInternal stopGraceful.run() finished");
-
-
-
             }
         }).start();
-
     }
 
     public void waitForPendingFutures() {
-
         try {
             while (!pendingFutures.isEmpty()) {
                 Future future = pendingFutures.take();
@@ -949,7 +929,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     @Override
     protected void goOffline() {
-
         super.goOffline();
 
         // stop change tracker
@@ -959,13 +938,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
         // TODO: stop remote requests in progress, but first
         // TODO: write a test that verifies this actually works
-
-
     }
 
     @Override
     protected void goOnline() {
-
         super.goOnline();
 
         // start change tracker
@@ -1003,5 +979,4 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             }
         }
     }
-
 }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -348,10 +348,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
         Future future = remoteRequestExecutor.submit(dl);
         pendingFutures.add(future);
-
     }
-
-
 
     // This invokes the tranformation block if one is installed and queues the resulting CBL_Revision
     private void queueDownloadedRevision(RevisionInternal rev) {
@@ -388,10 +385,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             }
         }
 
-        //TODO: rev.getBody().compact();
+        if(rev != null && rev.getBody() != null)
+            rev.getBody().compact();
 
         downloadsToInsert.queueObject(rev);
-
     }
 
 
@@ -543,12 +540,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                 Log.d(Log.TAG_SYNC, "%s insertDownloads() updating completedChangesCount from %d -> %d ", this, getCompletedChangesCount().get(), newCompletedChangesCount);
 
                 addToCompletedChangesCount(downloads.size());
-
             }
-
         }
-
-
     }
 
     @InterfaceAudience.Private
@@ -613,6 +606,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     // Add to batcher ... eventually it will be fed to -insertDownloads:.
 
                     // TODO: [gotRev.body compact];
+                    if(gotRev.getBody() != null)
+                        gotRev.getBody().compact();
                     Log.d(Log.TAG_SYNC, "%s: pullRemoteRevision add rev: %s to batcher: %s", PullerInternal.this, gotRev, downloadsToInsert);
                     downloadsToInsert.queueObject(gotRev);
                 }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -74,8 +74,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     /**
      * Actual work of starting the replication process.
      */
-    protected void beginReplicating()
-    {
+    protected void beginReplicating() {
         Log.d(Log.TAG_SYNC, "startReplicating()");
 
         initPendingSequences();

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -595,19 +595,21 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     revisionFailed(rev, e);
                 } else {
                     Map<String, Object> properties = (Map<String, Object>) result;
-                    PulledRevision gotRev = new PulledRevision(properties, db);
+                    PulledRevision gotRev = new PulledRevision(properties);
                     gotRev.setSequence(rev.getSequence());
-                    // Add to batcher ... eventually it will be fed to -insertDownloads:.
 
-                    if(gotRev.getBody() != null)
-                        gotRev.getBody().compact();
+                    //if(gotRev.getBody() != null)
+                    //    gotRev.getBody().compact();
+
                     Log.d(Log.TAG_SYNC, "%s: pullRemoteRevision add rev: %s to batcher: %s", PullerInternal.this, gotRev, downloadsToInsert);
+
+                    // Add to batcher ... eventually it will be fed to -insertRevisions:.
                     downloadsToInsert.queueObject(gotRev);
                 }
 
-                // Note that we've finished this task; then start another one if there
-                // are still revisions waiting to be pulled:
+                // Note that we've finished this task:
                 --httpConnectionCount;
+                // Start another task if there are still revisions waiting to be pulled:
                 pullRemoteRevisions();
             }
         });
@@ -714,7 +716,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             if (revID == null) {
                 continue;
             }
-            PulledRevision rev = new PulledRevision(docID, revID, deleted, db);
+            PulledRevision rev = new PulledRevision(docID, revID, deleted);
             rev.setRemoteSequenceID(lastSequence);
             Log.d(Log.TAG_SYNC, "%s: adding rev to inbox %s", this, rev);
 
@@ -841,6 +843,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         e.printStackTrace();
                     }
                     finally {
+                        // TODO: this might cause inappropriate IDLE notification.
                         fireTrigger(ReplicationTrigger.WAITING_FOR_CHANGES);
                     }
                     Log.e(Log.TAG_SYNC, "PullerInternal stopGraceful.run() finished");

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -573,6 +573,8 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                             }
                         }
                         multiPart.addPart("param1", new StringBody(compressed, "application/json", utf8charset, contentEncoding));
+                        uncompressed = null;
+                        compressed = null;
                     } catch (IOException e) {
                         throw new IllegalArgumentException(e);
                     }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1387,7 +1387,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                     assert(xformed.getProperties().get("_revisions").equals(rev.getProperties().get("_revisions")));
                     if (xformed.getProperties().get("_attachments") != null) {
                         // Insert 'revpos' properties into any attachments added by the callback:
-                        RevisionInternal mx = new RevisionInternal(xformed.getProperties(), db);
+                        RevisionInternal mx = new RevisionInternal(xformed.getProperties());
                         xformed = mx;
                         mx.mutateAttachments(new CollectionUtils.Functor<Map<String,Object>,Map<String,Object>>() {
                             public Map<String, Object> invoke(Map<String, Object> info) {

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -65,8 +65,6 @@ abstract class ReplicationInternal implements BlockingQueueListener{
 
     public static final String CHANNELS_QUERY_PARAM = "channels";
 
-    public static final String REPLICATOR_DATABASE_NAME = "_replicator";
-
     public static final int EXECUTOR_THREAD_POOL_SIZE = 5;
 
     private static int lastSessionID = 0;

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -941,7 +941,7 @@ public class Router implements Database.ChangeListener {
                 Status status = new Status(Status.OK);
                 Body docBody = new Body(doc);
                 if (noNewEdits) {
-                    rev = new RevisionInternal(docBody, db);
+                    rev = new RevisionInternal(docBody);
                     if(rev.getRevId() == null || rev.getDocId() == null || !rev.getDocId().equals(docID)) {
                         status =  new Status(Status.BAD_REQUEST);
                     } else {
@@ -1000,7 +1000,7 @@ public class Router implements Database.ChangeListener {
         for (String docID : body.keySet()) {
             List<String> revIDs = (List<String>)body.get(docID);
             for (String revID : revIDs) {
-                RevisionInternal rev = new RevisionInternal(docID, revID, false, db);
+                RevisionInternal rev = new RevisionInternal(docID, revID, false);
                 revs.add(rev);
             }
         }
@@ -1501,7 +1501,7 @@ public class Router implements Database.ChangeListener {
             prevRevID = getRevIDFromIfMatchHeader();
         }
 
-        RevisionInternal rev = new RevisionInternal(docID, null, deleting, db);
+        RevisionInternal rev = new RevisionInternal(docID, null, deleting);
         rev.setBody(body);
 
         RevisionInternal result = null;
@@ -1584,7 +1584,7 @@ public class Router implements Database.ChangeListener {
         } else {
             // PUT with new_edits=false -- forcible insertion of existing revision:
             Body body = new Body(bodyDict);
-            RevisionInternal rev = new RevisionInternal(body, _db);
+            RevisionInternal rev = new RevisionInternal(body);
             if(rev.getRevId() == null || rev.getDocId() == null || !rev.getDocId().equals(docID)) {
                 throw new CouchbaseLiteException(Status.BAD_REQUEST);
             }

--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -26,31 +26,28 @@ public class Batcher<T> {
 
     private int capacity;
     private int delayMs;
-    private int scheduledDelay;
     private BlockingQueue<T> inbox;
     private BatchProcessor<T> processor;
-    private boolean scheduled = false;
     private long lastProcessedTime = 0;
     private BlockingQueue<ScheduledFuture> pendingFutures;
     private Lock lock = new ReentrantLock();
 
     private Runnable processNowRunnable = new Runnable() {
-
         @Override
         public void run() {
-
+            lock.lock();
             try {
-                lock.lock();
                 processNow();
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 // we don't want this to crash the batcher
-                com.couchbase.lite.util.Log.e(Log.TAG_BATCHER, this + ": BatchProcessor throw exception", e);
-            } finally {
+                Log.e(Log.TAG_BATCHER, this + ": BatchProcessor throw exception", e);
+            }
+            finally {
                 lock.unlock();
             }
         }
     };
-
 
     /**
      * Initializes a batcher.
@@ -67,20 +64,16 @@ public class Batcher<T> {
         this.processor = processor;
         this.inbox = new LinkedBlockingQueue<T>();
         this.pendingFutures = new LinkedBlockingQueue<ScheduledFuture>();
-
     }
 
     private boolean isCurrentlyProcessing() {
-
         // we'll only get the lock if we ARENT currently processing
         boolean processingNotInProgress = lock.tryLock();
         if (processingNotInProgress) {
             // we don't actually need this lock, so unlock it immediately
             lock.unlock();
         }
-        boolean isProcessing = !processingNotInProgress;
-        return isProcessing;
-
+        return !processingNotInProgress;
     }
 
     /**
@@ -113,7 +106,6 @@ public class Batcher<T> {
             Log.v(Log.TAG_BATCHER, "%s: calling scheduleWithDelay(%d)", this, suggestedDelay);
             scheduleWithDelay(suggestedDelay);
         }
-
     }
 
     public void waitForPendingFutures() {
@@ -178,11 +170,10 @@ public class Batcher<T> {
         }
     }
 
-    private void processNow() {
-
+    private void processNow()
+    {
         Log.v(Log.TAG_BATCHER, this + ": processNow() called");
 
-        scheduled = false;
         List<T> toProcess = new ArrayList<T>();
 
         if (inbox == null || inbox.size() == 0) {
@@ -211,9 +202,7 @@ public class Batcher<T> {
                 i += 1;
             }
 
-
             Log.v(Log.TAG_BATCHER, "%s: inbox.size() > capacity, moving %d items from inbox -> toProcess array", this, toProcess.size());
-
         }
 
         if(toProcess != null && toProcess.size() > 0) {
@@ -255,14 +244,11 @@ public class Batcher<T> {
         }
         forgetExpiredFutures(futuresToForget);
 
-
         Log.v(Log.TAG_BATCHER, "%s: scheduleWithDelay called with delayMs: %d ms", this, suggestedDelay);
-        scheduledDelay = suggestedDelay;
         Log.v(Log.TAG_BATCHER, "workExecutor.schedule() with delayMs: %d ms", suggestedDelay);
         ScheduledFuture pendingFuture = workExecutor.schedule(processNowRunnable, suggestedDelay, TimeUnit.MILLISECONDS);
         Log.v(Log.TAG_BATCHER, "%s: created future: %s", this, pendingFuture);
         pendingFutures.add(pendingFuture);
-
     }
 
     private void forgetExpiredFutures(List<ScheduledFuture> futuresToForget) {
@@ -274,7 +260,6 @@ public class Batcher<T> {
     }
 
     private void unscheduleAllPending() {
-
         // keep a list of expired pending futures so we can remove them from pendingFutures
         List<ScheduledFuture> futuresToForget = new ArrayList<ScheduledFuture>();
 
@@ -286,7 +271,6 @@ public class Batcher<T> {
         }
 
         forgetExpiredFutures(futuresToForget);
-
     }
 
     /*
@@ -314,7 +298,6 @@ public class Batcher<T> {
             }
 
             Log.v(Log.TAG_BATCHER, "%s: delayToUse() delta: %d, delayToUse: %d, delayMs: %d", this, delta, delayToUse, delayMs);
-
         }
         return delayToUse;
     }

--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -38,12 +38,10 @@ public class Batcher<T> {
             lock.lock();
             try {
                 processNow();
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 // we don't want this to crash the batcher
                 Log.e(Log.TAG_BATCHER, this + ": BatchProcessor throw exception", e);
-            }
-            finally {
+            } finally {
                 lock.unlock();
             }
         }
@@ -170,8 +168,7 @@ public class Batcher<T> {
         }
     }
 
-    private void processNow()
-    {
+    private void processNow() {
         Log.v(Log.TAG_BATCHER, this + ": processNow() called");
 
         List<T> toProcess = new ArrayList<T>();
@@ -205,7 +202,7 @@ public class Batcher<T> {
             Log.v(Log.TAG_BATCHER, "%s: inbox.size() > capacity, moving %d items from inbox -> toProcess array", this, toProcess.size());
         }
 
-        if(toProcess != null && toProcess.size() > 0) {
+        if (toProcess != null && toProcess.size() > 0) {
             Log.v(Log.TAG_BATCHER, "%s: invoking processor %s with %d items ", this, processor, toProcess.size());
             processor.process(toProcess);
         } else {

--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -235,11 +235,16 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
 
     @Override
     public void appendToPart(byte[] data) {
+        appendToPart(data, 0, data.length);
+    }
+
+    @Override
+    public void appendToPart(final byte[] data, int off, int len) {
         if (jsonBuffer != null) {
-            jsonBuffer.append(data, 0, data.length);
+            jsonBuffer.append(data, off, len);
         }
         else {
-            curAttachment.appendData(data);
+            curAttachment.appendData(data, off, len);
         }
     }
 

--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -53,7 +53,7 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to parse json buffer", e);
         }
-
+        json = null;
         jsonBuffer = null;
     }
 
@@ -89,6 +89,14 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
         }
         else {
             jsonBuffer.append(data, 0, data.length);
+        }
+    }
+    public void appendData(byte[] data, int off, int len) {
+        if (multipartReader != null) {
+            multipartReader.appendData(data, off, len);
+        }
+        else {
+            jsonBuffer.append(data, off, len);
         }
     }
 
@@ -179,7 +187,6 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
                 Log.w(Log.TAG_REMOTE_REQUEST, "Attachment '%s' sent inline (len=%d).  Large attachments " +
                         "should be sent in MIME parts for reduced memory overhead.", attachmentName, length);
             }
-
         }
 
         if (numAttachmentsInDoc < attachmentsByMd5Digest.size()) {
@@ -216,11 +223,7 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
                 }
             }
         }
-
-
     }
-
-
 
     @Override
     public void appendToPart(byte[] data) {
@@ -243,7 +246,5 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
             attachmentsByMd5Digest.put(md5String, curAttachment);
             curAttachment = null;
         }
-
-
     }
 }

--- a/src/main/java/com/couchbase/lite/support/MultipartReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartReader.java
@@ -147,7 +147,7 @@ public class MultipartReader {
                     // The entire message might start with a boundary without a leading CRLF.
                     byte[] boundaryWithoutLeadingCRLF = getBoundaryWithoutLeadingCRLF();
                     if (bufLen >= boundaryWithoutLeadingCRLF.length) {
-                        if (memcmp(buffer.toByteArray(), boundaryWithoutLeadingCRLF, boundaryWithoutLeadingCRLF.length)) {
+                        if (memcmp(buffer.buffer(), boundaryWithoutLeadingCRLF, boundaryWithoutLeadingCRLF.length)) {
                             deleteUpThrough(boundaryWithoutLeadingCRLF.length);
                             nextState = MultipartReaderState.kInHeaders;
                         } else {
@@ -179,7 +179,7 @@ public class MultipartReader {
                 }
                 case kInHeaders: {
                     // First check for the end-of-message string ("--" after separator):
-                    if (bufLen >= kEOM.length && memcmp(buffer.toByteArray(), kEOM, kEOM.length)) {
+                    if (bufLen >= kEOM.length && memcmp(buffer.buffer(), kEOM, kEOM.length)) {
                         state = MultipartReaderState.kAtEnd;
                         close();
                         return;

--- a/src/main/java/com/couchbase/lite/support/MultipartReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartReader.java
@@ -21,6 +21,7 @@ public class MultipartReader {
     }
     private static final Charset utf8 = Charset.forName("UTF-8");
     private static final byte[] kCRLFCRLF = new String("\r\n\r\n").getBytes(utf8);
+    private static final byte[] kEOM = new String("--").getBytes(utf8);
 
     private MultipartReaderState state = null;
     private ByteArrayBuffer buffer = null;
@@ -56,10 +57,6 @@ public class MultipartReader {
         return state == MultipartReaderState.kAtEnd;
     }
 
-    private byte[] eomBytes() {
-        return new String("--").getBytes(Charset.forName("UTF-8"));
-    }
-
     private boolean memcmp(byte[] array1, byte[] array2, int len) {
         boolean equals = true;
         for (int i=0; i<len; i++) {
@@ -71,10 +68,9 @@ public class MultipartReader {
     }
 
     public Range searchFor(byte[] pattern, int start) {
-
         KMPMatch searcher = new KMPMatch();
-        int matchIndex = searcher.indexOf(buffer.toByteArray(), pattern, start);
-
+        int buffLen = Math.min(buffer.length(), buffer.buffer().length);
+        int matchIndex = searcher.indexOf(buffer.buffer(),buffLen, pattern, start);
         if (matchIndex != -1) {
             return new Range(matchIndex, pattern.length);
         }
@@ -99,20 +95,24 @@ public class MultipartReader {
                 String key = headerTokenizer.nextToken().trim();
                 String value = headerTokenizer.nextToken().trim();
                 headers.put(key, value);
-
             }
         }
-
     }
 
     private void deleteUpThrough(int location) {
-
         // int start = location + 1;  // start at the first byte after the location
 
-        byte[] newBuffer = Arrays.copyOfRange(buffer.toByteArray(), location, buffer.length());
-        buffer.clear();
-        buffer.append(newBuffer, 0, newBuffer.length);
+        if(location <= 0) return;
 
+        byte[] b = buffer.buffer();
+        int len = buffer.length();
+
+        int j = 0;
+        int i = location;
+        while(i < len){
+            b[j++] = b[i++];
+        }
+        buffer.setLength(j);
     }
 
     private void trimBuffer() {
@@ -120,11 +120,9 @@ public class MultipartReader {
         int boundaryLen = getBoundary().length;
         if (bufLen > boundaryLen) {
             // Leave enough bytes in _buffer that we can find an incomplete boundary string
-            byte[] dataToAppend = Arrays.copyOfRange(buffer.toByteArray(), 0, bufLen - boundaryLen);
-            delegate.appendToPart(dataToAppend);
+            delegate.appendToPart(buffer.buffer(), 0, bufLen - boundaryLen);
             deleteUpThrough(bufLen - boundaryLen);
         }
-
     }
 
     public void appendData(byte[] data) {
@@ -144,13 +142,11 @@ public class MultipartReader {
         do {
             nextState = MultipartReaderState.kUninitialized;
             int bufLen = buffer.length();
-            // Log.d(Database.TAG, "appendData.  bufLen: " + bufLen);
             switch (state) {
                 case kAtStart: {
                     // The entire message might start with a boundary without a leading CRLF.
                     byte[] boundaryWithoutLeadingCRLF = getBoundaryWithoutLeadingCRLF();
                     if (bufLen >= boundaryWithoutLeadingCRLF.length) {
-                        // if (Arrays.equals(buffer.toByteArray(), boundaryWithoutLeadingCRLF)) {
                         if (memcmp(buffer.toByteArray(), boundaryWithoutLeadingCRLF, boundaryWithoutLeadingCRLF.length)) {
                             deleteUpThrough(boundaryWithoutLeadingCRLF.length);
                             nextState = MultipartReaderState.kInHeaders;
@@ -171,8 +167,7 @@ public class MultipartReader {
                     Range r = searchFor(boundary, start);
                     if (r.getLength() > 0) {
                         if (state == MultipartReaderState.kInBody) {
-                            byte[] dataToAppend = Arrays.copyOfRange(buffer.toByteArray(), 0, r.getLocation());
-                            delegate.appendToPart(dataToAppend);
+                            delegate.appendToPart(buffer.buffer(), 0, r.getLocation());
                             delegate.finishedPart();
                         }
                         deleteUpThrough(r.getLocation() + r.getLength());
@@ -184,8 +179,7 @@ public class MultipartReader {
                 }
                 case kInHeaders: {
                     // First check for the end-of-message string ("--" after separator):
-                    if (bufLen >= 2 &&
-                            memcmp(buffer.toByteArray(), eomBytes(), 2)) {
+                    if (bufLen >= kEOM.length && memcmp(buffer.toByteArray(), kEOM, kEOM.length)) {
                         state = MultipartReaderState.kAtEnd;
                         close();
                         return;
@@ -193,18 +187,13 @@ public class MultipartReader {
                     // Otherwise look for two CRLFs that delimit the end of the headers:
                     Range r = searchFor(kCRLFCRLF, 0);
                     if (r.getLength() > 0) {
-                        byte[] headersBytes = Arrays.copyOf(buffer.toByteArray(), r.getLocation());
-                        // byte[] headersBytes = Arrays.copyOfRange(buffer.toByteArray(), 0, r.getLocation())  <-- better?
-
-                        String headersString = new String(headersBytes, utf8);
+                        String headersString = new String(buffer.buffer(), 0, r.getLocation(), utf8);
                         parseHeaders(headersString);
                         deleteUpThrough(r.getLocation() + r.getLength());
                         delegate.startedPart(headers);
                         nextState = MultipartReaderState.kInBody;
-
                     }
                     break;
-
                 }
                 default: {
                     throw new IllegalStateException("Unexpected data after end of MIME body");
@@ -216,12 +205,10 @@ public class MultipartReader {
             }
 
         } while (nextState != MultipartReaderState.kUninitialized && buffer.length() > 0);
-
-
     }
 
     private void close() {
-        if(buffer!=null)buffer.clear();
+        if(buffer!=null) buffer.clear();
         buffer = null;
         boundary = null;
         boundaryWithoutLeadingCRLF = null;
@@ -258,7 +245,6 @@ public class MultipartReader {
             }
         }
     }
-
 }
 
 /**
@@ -269,7 +255,7 @@ class KMPMatch {
     /**
      * Finds the first occurrence of the pattern in the text.
      */
-    public int indexOf(byte[] data, byte[] pattern, int dataOffset) {
+    public int indexOf(byte[] data, int dataLength, byte[] pattern, int dataOffset) {
 
         int[] failure = computeFailure(pattern);
 
@@ -277,7 +263,7 @@ class KMPMatch {
         if (data.length == 0)
             return -1;
 
-        final int dataLength = data.length;
+        //final int dataLength = data.length;
         final int patternLength = pattern.length;
 
         for (int i = dataOffset; i < dataLength; i++) {
@@ -310,7 +296,6 @@ class KMPMatch {
             }
             failure[i] = j;
         }
-
         return failure;
     }
 }

--- a/src/main/java/com/couchbase/lite/support/MultipartReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartReader.java
@@ -126,14 +126,17 @@ public class MultipartReader {
     }
 
     public void appendData(byte[] data) {
+        appendData(data, 0, data.length);
+    }
+    public void appendData(byte[] data, int off, int len) {
 
         if (buffer == null) {
             return;
         }
-        if (data.length == 0) {
+        if (len == 0) {
             return;
         }
-        buffer.append(data, 0, data.length);
+        buffer.append(data, off, len);
 
         MultipartReaderState nextState;
         do {

--- a/src/main/java/com/couchbase/lite/support/MultipartReaderDelegate.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartReaderDelegate.java
@@ -6,7 +6,9 @@ public interface MultipartReaderDelegate {
 
     public void startedPart(Map<String, String> headers);
 
+    // obsolete
     public void appendToPart(byte[] data);
+    public void appendToPart(final byte[] data, int off, int len);
 
     public void finishedPart();
 

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
@@ -91,7 +91,7 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
                             if (contentTypeHeader != null) {
                                 // multipart
                                 if (contentTypeHeader.getValue().contains("multipart/related")) {
-                                    MultipartDocumentReader reader = new MultipartDocumentReader(response, db);
+                                    MultipartDocumentReader reader = new MultipartDocumentReader(db);
                                     reader.setHeaders(Utils.headersToMap(response.getAllHeaders()));
                                     byte[] buffer = new byte[BUF_LEN];
                                     int numBytesRead = 0;

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public class RemoteMultipartRequest extends RemoteRequest {
 
-    private MultipartEntity multiPart;
+    private MultipartEntity multiPart = null;
 
     public RemoteMultipartRequest(ScheduledExecutorService workExecutor,
                                   HttpClientFactory clientFactory, String method, URL url,
@@ -34,7 +34,6 @@ public class RemoteMultipartRequest extends RemoteRequest {
             HttpPut putRequest = new HttpPut(url.toExternalForm());
             putRequest.setEntity(multiPart);
             request = putRequest;
-
         } else if (method.equalsIgnoreCase("POST")) {
             HttpPost postRequest = new HttpPost(url.toExternalForm());
             postRequest.setEntity(multiPart);

--- a/src/main/java/com/couchbase/lite/support/SequenceMap.java
+++ b/src/main/java/com/couchbase/lite/support/SequenceMap.java
@@ -43,6 +43,10 @@ public class SequenceMap {
 		return sequences.isEmpty();
 	}
 
+    public synchronized int count(){
+        return sequences.size();
+    }
+
     /**
      * Returns the maximum consecutively-removed sequence number.
      * This is one less than the minimum remaining sequence number.


### PR DESCRIPTION
- Create new instance of ObjectMapper instead of reusing it. ObjectMapper kept a lot of memory because of its optimization.
- Call RevisionInternal.Body.compact() before putting revision into downloadedToInsert queue. JSON string is much smaller than Map object representation.
- Release json string form body after insert revision into database. With current architecture, revision is not release from downloadToInsert queue immediately after insert it into database.
- Pausing ChangeTracker if size of queue for download changes and following tasks are more than 200.
- Many other minor improvements