### PR TITLE
Fixed #452 - Error after close DB client

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1184,7 +1184,7 @@ public final class Database {
                 try {
                     boolean success = latch.await(20, TimeUnit.SECONDS);
                     if (!success) {
-                        Log.w(Log.TAG_DATABASE, "Replicator could not stop in 30 second.");
+                        Log.w(Log.TAG_DATABASE, "Replicator could not stop in 20 second.");
                     }
                 } catch (Exception e) {
                     Log.w(Log.TAG_DATABASE, e.getMessage());

--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -398,6 +398,8 @@ public final class Manager {
      */
     @InterfaceAudience.Private
     Future runAsync(Runnable runnable) {
+        if (workExecutor.isShutdown())
+            return null;
         return workExecutor.submit(runnable);
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -185,6 +185,8 @@ abstract class ReplicationInternal implements BlockingQueueListener{
     protected void fireTrigger(final ReplicationTrigger trigger) {
         Log.w(Log.TAG_SYNC, "[fireTrigger()] => " + trigger);
         // All state machine triggers need to happen on the replicator thread
+        if (workExecutor.isShutdown())
+            return;
         workExecutor.submit(new Runnable() {
             @Override
             public void run() {
@@ -610,8 +612,6 @@ abstract class ReplicationInternal implements BlockingQueueListener{
 
             Future future = request.submit();
             return future;
-
-
         } catch (MalformedURLException e) {
             Log.e(Log.TAG_SYNC, "Malformed URL for async request", e);
         }
@@ -1016,7 +1016,10 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                     Log.e(Log.TAG_SYNC, "Exception notifying replication listener: %s", e);
                 }
             }
-        } else { // ASYNC
+        } else {
+            // ASYNC
+            if (workExecutor.isShutdown())
+                return;
             workExecutor.submit(new Runnable() {
                 @Override
                 public void run() {

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -116,15 +116,16 @@ public class RemoteRequestRetry<T> implements Future<T> {
 
         RemoteRequest request = generateRemoteRequest();
 
-        if(gzip){
+        if (gzip) {
             request.setCompressedRequest(true);
         }
 
-        Future future = requestExecutor.submit(request);
-        pendingRequests.add(future);
+        if (!requestExecutor.isShutdown()) {
+            Future future = requestExecutor.submit(request);
+            pendingRequests.add(future);
+        }
 
         return this;
-
     }
 
     private RemoteRequest generateRemoteRequest() {

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -274,10 +274,10 @@ public class Utils {
         pool.shutdown(); // Disable new tasks from being submitted
         try {
             // Wait a while for existing tasks to terminate
-            if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+            if (!pool.awaitTermination(20, TimeUnit.SECONDS)) {
                 pool.shutdownNow(); // Cancel currently executing tasks
                 // Wait a while for tasks to respond to being cancelled
-                if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+                if (!pool.awaitTermination(20, TimeUnit.SECONDS)) {
                     Log.e(Log.TAG_DATABASE, "Pool did not terminate");
                 }
             }

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -17,6 +17,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -28,7 +30,7 @@ public class Utils {
      * @param obj1 object1 being compared
      * @param obj2 object2 being compared
      * @return true if both are non-null and obj1.equals(obj2), or true if both are null.
-     *         otherwise return false.
+     * otherwise return false.
      */
     public static boolean isEqual(Object obj1, Object obj2) {
         if (obj1 != null) {
@@ -42,7 +44,7 @@ public class Utils {
      * in CBLMisc.m
      * BOOL CBLIsPermanentError( NSError* error )
      */
-    public static boolean isPermanentError(Throwable throwable){
+    public static boolean isPermanentError(Throwable throwable) {
         if (throwable instanceof CouchbaseLiteException) {
             CouchbaseLiteException e = (CouchbaseLiteException) throwable;
             return isPermanentError(e.getCBLStatus().getCode());
@@ -53,18 +55,18 @@ public class Utils {
             return false;
         }
     }
+
     /**
      * in CBLMisc.m
      * BOOL CBLIsPermanentError( NSError* error )
      */
-    public static boolean isPermanentError(int code){
+    public static boolean isPermanentError(int code) {
         // TODO: make sure if 406 is acceptable error
         // 406 - in Test cases, server return 406 because of CouchDB API
         //       http://docs.couchdb.org/en/latest/api/database/bulk-api.html
         //       GET /{db}/_all_docs or POST /{db}/_all_docs
         return (code >= 400 && code <= 405) || (code >= 407 && code <= 499);
     }
-
 
     public static boolean isTransientError(Throwable throwable) {
 
@@ -119,11 +121,14 @@ public class Utils {
         return result;
     }
 
-    /** cribbed from http://stackoverflow.com/questions/9655181/convert-from-byte-array-to-hex-string-in-java */
+    /**
+     * cribbed from http://stackoverflow.com/questions/9655181/convert-from-byte-array-to-hex-string-in-java
+     */
     final protected static char[] hexArray = "0123456789abcdef".toCharArray();
+
     public static String bytesToHex(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];
-        for ( int j = 0; j < bytes.length; j++ ) {
+        for (int j = 0; j < bytes.length; j++) {
             int v = bytes[j] & 0xFF;
             hexChars[j * 2] = hexArray[v >>> 4];
             hexChars[j * 2 + 1] = hexArray[v & 0x0F];
@@ -165,78 +170,122 @@ public class Utils {
     }
 
     // check if contentEncoding is gzip
-    public static boolean isGzip(HttpEntity entity){
+    public static boolean isGzip(HttpEntity entity) {
         return isGzip(entity.getContentEncoding());
     }
 
     // check if contentEncoding is gzip
-    public static boolean isGzip(Header contentEncoding){
+    public static boolean isGzip(Header contentEncoding) {
         return contentEncoding != null && isGzip(contentEncoding.getValue());
     }
 
     // check if contentEncoding is gzip
-    public static boolean isGzip(String contentEncoding){
+    public static boolean isGzip(String contentEncoding) {
         return contentEncoding != null && contentEncoding.contains("gzip");
     }
 
     // to gzip
-    public static byte[] compressByGzip(byte[] sourceBytes){
+    public static byte[] compressByGzip(byte[] sourceBytes) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try{
+        try {
             GZIPOutputStream gzip = null;
             try {
                 gzip = new GZIPOutputStream(out);
                 gzip.write(sourceBytes);
                 gzip.close();
-            }
-            catch (IOException ex){
+            } catch (IOException ex) {
                 return null;
-            }
-            finally {
-                try{ if(gzip != null) { gzip.close(); } } catch(IOException ex) {}
+            } finally {
+                try {
+                    if (gzip != null) {
+                        gzip.close();
+                    }
+                } catch (IOException ex) {
+                }
             }
 
-            return  out.toByteArray();
-        }
-        finally {
-            try{ out.close(); }catch(IOException ex){}
+            return out.toByteArray();
+        } finally {
+            try {
+                out.close();
+            } catch (IOException ex) {
+            }
         }
     }
 
     // from gzip
     public static int CHUNK_SIZE = 8192; // 1024 * 8
-    public static byte[] decompressByGzip(byte[] sourceBytes){
+
+    public static byte[] decompressByGzip(byte[] sourceBytes) {
         byte[] buffer = null;
         ByteArrayOutputStream out = null;
         ByteArrayInputStream in = null;
         GZIPInputStream gzip = null;
         try {
-            out    = new ByteArrayOutputStream();
+            out = new ByteArrayOutputStream();
             buffer = new byte[CHUNK_SIZE];
-            in     = new ByteArrayInputStream(sourceBytes);
-            gzip   = new GZIPInputStream(in);
+            in = new ByteArrayInputStream(sourceBytes);
+            gzip = new GZIPInputStream(in);
             int len = 0;
             while ((len = gzip.read(buffer, 0, CHUNK_SIZE)) != -1) {
                 out.write(buffer, 0, len);
             }
             return out.toByteArray();
-        }
-        catch (IOException ex){
+        } catch (IOException ex) {
             Log.w(Log.TAG, "Failed to decompress gzipped data: " + ex.getMessage());
             return null;
-        }
-        finally {
-            try{ if(out  != null) { out.close();  } } catch(IOException ex) {}
-            try{ if(in   != null) { in.close();   } } catch(IOException ex) {}
-            try{ if(gzip != null) { gzip.close(); } } catch(IOException ex) {}
+        } finally {
+            try {
+                if (out != null) {
+                    out.close();
+                }
+            } catch (IOException ex) {
+            }
+            try {
+                if (in != null) {
+                    in.close();
+                }
+            } catch (IOException ex) {
+            }
+            try {
+                if (gzip != null) {
+                    gzip.close();
+                }
+            } catch (IOException ex) {
+            }
         }
     }
 
-    public static Map<String, String> headersToMap(Header[] headers){
+    public static Map<String, String> headersToMap(Header[] headers) {
         Map<String, String> map = new HashMap<String, String>();
-        for(int i = 0; i < headers.length; i++){
+        for (int i = 0; i < headers.length; i++) {
             map.put(headers[i].getName(), headers[i].getValue());
         }
         return map;
+    }
+
+    /**
+     * The following method shuts down an ExecutorService in two phases,
+     * first by calling shutdown to reject incoming tasks, and then calling shutdownNow,
+     * if necessary, to cancel any lingering tasks:
+     * http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ExecutorService.html
+     */
+    public static void shutdownAndAwaitTermination(ExecutorService pool) {
+        pool.shutdown(); // Disable new tasks from being submitted
+        try {
+            // Wait a while for existing tasks to terminate
+            if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+                pool.shutdownNow(); // Cancel currently executing tasks
+                // Wait a while for tasks to respond to being cancelled
+                if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
+                    Log.e(Log.TAG_DATABASE, "Pool did not terminate");
+                }
+            }
+        } catch (InterruptedException ie) {
+            // (Re-)Cancel if current thread also interrupted
+            pool.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        }
     }
 }


### PR DESCRIPTION
Fixed #452 - Error after close DB client

Problem:
- Executor which is used in Manager and ReplicatorInternal caused thread leak, it requires to call shutdown() method.

Solution:
- Shuts down Executor Thread which is created by Manager
- Shuts down Executor Thread which is created by Replicator
- Wait all replicators become STOPPED state in Database.close()
- Implements two phases Executor shutdown
- Applied code style to Manager.java and Utils.java