### PR TITLE
Fixed #296 - NPE thrown when running ApiTest.testLiveQueryRun

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -381,8 +381,15 @@ public final class View {
      */
     @InterfaceAudience.Private
     public void databaseClosing() {
-        database = null;
-        viewId = 0;
+        // some tasks could be still in queue of thread, CBLManagerWorkExecutor.
+        // set null to database variable from CBLManagerWorkExecutor.
+        database.getManager().runAsync(new Runnable() {
+            @Override
+            public void run() {
+                database = null;
+                viewId = 0;
+            }
+        });
     }
 
     /*** Indexing ***/


### PR DESCRIPTION
Problem:
- View's task is executed with the thread, CBLManagerWorkExecutor. Sometimes the task is still in queue. Calling databaseClosing() of View before all tasks are completed causes NPE.

Solution:
- Processing closing task in the thread, CBLManagerWorkExecutor.