### PR TITLE
Fixed #476

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1161,7 +1161,7 @@ public final class Database {
     /**
      * @exclude
      */
-    @InterfaceAudience.Private
+    @InterfaceAudience.Public
     public boolean close() {
         if (!open) {
             return false;

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1158,9 +1158,6 @@ public final class Database {
         }
     }
 
-    /**
-     * @exclude
-     */
     @InterfaceAudience.Public
     public boolean close() {
         if (!open) {


### PR DESCRIPTION
As commented in the #476 ticket, Database.close() method is already public method. I just change its annotation to @InterfaceAudience.Public and remove `@exclude` for javadoc