### PR TITLE
Fixed #483 - Unit Test failure on Jenkins server (ChangeTrackerTest)

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -71,6 +71,7 @@ public final class Manager {
 
     public static final String USER_AGENT = "CouchbaseLite/" + Version.getVersionName();
 
+    private static final ObjectMapper mapper = new ObjectMapper();
     private ManagerOptions options;
     private File directoryFile;
     private Map<String, Database> databases;
@@ -79,12 +80,13 @@ public final class Manager {
     private HttpClientFactory defaultHttpClientFactory;
     private Context context;
 
+
     /**
      * @exclude
      */
     @InterfaceAudience.Private
     public static ObjectMapper getObjectMapper() {
-        return new ObjectMapper();
+        return mapper;
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -417,7 +417,7 @@ public class ChangeTracker implements Runnable {
                     // frequently happens when we're shutting down and have to
                     // close the socket underneath our read.
                 } else {
-                    Log.e(Log.TAG_CHANGE_TRACKER, this + ": Exception in change tracker", e);
+                    Log.w(Log.TAG_CHANGE_TRACKER, this + ": Exception in change tracker", e);
                     this.error = e;
                 }
 


### PR DESCRIPTION
Problem:
- Code changes to fix #447, especially  change for how create ObjectMapper in Manager.java. By changing it to recreate the ObjectMapper instance whenever it is requested, all JSON parsing and serialization become slower.

Solution:
- ObjectMapper is reused. Instead of creating ObjectMapper whenever it is requested.
- One of Error message in ChageTracer from Error to Warning. (not related with issue)