### PR TITLE
Fixed #497 - View.updateIndex() crashes with older SQLite.

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -523,6 +523,14 @@ public final class View {
 
             boolean keepGoing = cursor.moveToNext();
             while (keepGoing) {
+
+                // NOTE: skip row if 1st column is null
+                // https://github.com/couchbase/couchbase-lite-java-core/issues/497
+                if (cursor.isNull(0)) {
+                    keepGoing = cursor.moveToNext();
+                    continue;
+                }
+
                 long docID = cursor.getLong(0);
 
                 // Reconstitute the document as a dictionary:
@@ -538,8 +546,11 @@ public final class View {
                 boolean noAttachments = cursor.getInt(5) > 0;
                 boolean deleted = cursor.getInt(6) > 0;
 
-                while ((keepGoing = cursor.moveToNext()) &&  cursor.getLong(0) == docID) {
+                while ((keepGoing = cursor.moveToNext()) && (cursor.isNull(0) || cursor.getLong(0) == docID)) {
                     // Skip rows with the same doc_id -- these are losing conflicts.
+
+                    // NOTE: Or Skip rows if 1st column is null
+                    // https://github.com/couchbase/couchbase-lite-java-core/issues/497
                 }
 
                 if (minLastSequence > 0) {

--- a/src/main/java/com/couchbase/lite/storage/Cursor.java
+++ b/src/main/java/com/couchbase/lite/storage/Cursor.java
@@ -24,4 +24,5 @@ public interface Cursor {
     long getLong(int columnIndex);
     byte[] getBlob(int columnIndex);
     void close();
+    boolean isNull(int columnIndex);
 }


### PR DESCRIPTION
Problem:
- Cursor.getXXX() throws Exception if column is null. It makes app crashes.
- With older version of SQLite, SQL query returns rows with null column. But latest SQLite does not cause this issue.
- Rows with null column are usually duplicate (from the comment, it seems losing conflict)

Solution:
- Check if column 0 is null before calling getXXX() to avoid Exception.