### PR TITLE
Using request headers for multipart request

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
@@ -42,6 +42,7 @@ public class RemoteMultipartRequest extends RemoteRequest {
             throw new IllegalArgumentException("Invalid request method: " + method);
         }
 
+        addRequestHeaders(request);
         request.addHeader("Accept", "*/*");
 
         executeRequest(httpClient, request);


### PR DESCRIPTION
The multipart requests don't include headers set for the replication, this commit fixes the problem.