### PR TITLE
Eliminated getResourceAsStream() to minimize memory usage 

### DIFF
--- a/src/main/java/com/couchbase/lite/util/LoggerFactory.java
+++ b/src/main/java/com/couchbase/lite/util/LoggerFactory.java
@@ -20,7 +20,7 @@ import com.couchbase.lite.Database;
 
 public class LoggerFactory {
 
-    static String classname = "com.couchbase.lite.util.LoggerImpl";
+    static String classname = "com.couchbase.lite.util.SimpleLogger";
 
     public static Logger createLogger() {
         try {

--- a/src/main/java/com/couchbase/lite/util/LoggerFactory.java
+++ b/src/main/java/com/couchbase/lite/util/LoggerFactory.java
@@ -29,7 +29,8 @@ public class LoggerFactory {
             Logger logger = (Logger) clazz.newInstance();
             return logger;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to create logger. classname: " + classname, e);
+            System.err.println("Failed to load the logger: " + classname + ". Use SystemLogger.");
+            return new SystemLogger();
         }
     }
 }

--- a/src/main/java/com/couchbase/lite/util/LoggerFactory.java
+++ b/src/main/java/com/couchbase/lite/util/LoggerFactory.java
@@ -18,42 +18,18 @@ package com.couchbase.lite.util;
 
 import com.couchbase.lite.Database;
 
-import java.io.InputStream;
-
 public class LoggerFactory {
 
+    static String classname = "com.couchbase.lite.util.LoggerImpl";
+
     public static Logger createLogger() {
-
-        String classname = "";
-        String resource = "services/com.couchbase.lite.util.Logger";
-
         try {
-            InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
-            if (inputStream == null) {
-                // Return default System logger.
-                Log.d(Database.TAG, "Unable to load %s. Falling back to SystemLogger", resource);
-                return new SystemLogger();
-            } else {
-              try {
-                byte[] bytes = TextUtils.read(inputStream);
-                classname = new String(bytes);
-                if (classname == null || classname.isEmpty()) {
-                    // Return default System logger.
-                    Log.d(Database.TAG, "Unable to load %s. Falling back to SystemLogger", resource);
-                    return new SystemLogger();
-                }
-                Log.v(Database.TAG, "Loading logger: %s", classname);
-                Class clazz = Class.forName(classname);
-                Logger logger = (Logger) clazz.newInstance();
-                return logger;
-              } finally {
-                inputStream.close();
-              }
-            }
+            Log.v(Database.TAG, "Loading logger: %s", classname);
+            Class clazz = Class.forName(classname);
+            Logger logger = (Logger) clazz.newInstance();
+            return logger;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to logger.  Resource: " + resource + " classname: " + classname, e);
+            throw new RuntimeException("Failed to create logger. classname: " + classname, e);
         }
-
-
     }
 }


### PR DESCRIPTION
- Eliminated getResourceAsStream()
- Set static Logger class name instead of dynamic classname 
- return SystemLogger if error occurs.
