### PR TITLE
Fixed #452 - Application does not terminate after having network error

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -278,7 +278,8 @@ abstract class ReplicationInternal implements BlockingQueueListener{
     protected void close() {
         // shutdown ScheduledExecutorService. Without shutdown, cause thread leak
         if (remoteRequestExecutor != null && !remoteRequestExecutor.isShutdown()) {
-            Utils.shutdownAndAwaitTermination(remoteRequestExecutor);
+            // Note: Time to wait is set 60 sec because RemoteRequest's socket timeout is set 60 seconds.
+            Utils.shutdownAndAwaitTermination(remoteRequestExecutor, 60);
         }
     }
 

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -25,7 +25,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.ClientContext;
-import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -89,8 +88,6 @@ public class RemoteRequest implements Runnable {
             Log.v(Log.TAG_SYNC, "%s: RemoteRequest run() called, url: %s", this, url);
 
             HttpClient httpClient = clientFactory.getHttpClient();
-
-            ClientConnectionManager manager = httpClient.getConnectionManager();
 
             preemptivelySetAuthCredentials(httpClient);
 

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -269,15 +269,17 @@ public class Utils {
      * first by calling shutdown to reject incoming tasks, and then calling shutdownNow,
      * if necessary, to cancel any lingering tasks:
      * http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ExecutorService.html
+     *
+     * @param timeToWait - Seconds
      */
-    public static void shutdownAndAwaitTermination(ExecutorService pool) {
+    public static void shutdownAndAwaitTermination(ExecutorService pool, long timeToWait) {
         pool.shutdown(); // Disable new tasks from being submitted
         try {
             // Wait a while for existing tasks to terminate
-            if (!pool.awaitTermination(20, TimeUnit.SECONDS)) {
+            if (!pool.awaitTermination(timeToWait, TimeUnit.SECONDS)) {
                 pool.shutdownNow(); // Cancel currently executing tasks
                 // Wait a while for tasks to respond to being cancelled
-                if (!pool.awaitTermination(20, TimeUnit.SECONDS)) {
+                if (!pool.awaitTermination(timeToWait, TimeUnit.SECONDS)) {
                     Log.e(Log.TAG_DATABASE, "Pool did not terminate");
                 }
             }
@@ -287,5 +289,9 @@ public class Utils {
             // Preserve interrupt status
             Thread.currentThread().interrupt();
         }
+    }
+
+    public static void shutdownAndAwaitTermination(ExecutorService pool) {
+        shutdownAndAwaitTermination(pool, 20);
     }
 }


### PR DESCRIPTION
Problem:
- In case of failing the connection with server, CBL keeps retrying till retry counter reaches maximum. It blocks app terminates.

Solution:
- Give 60sec to ReplicationInternal to wait remoteRequestExecutor terminated
- Clean unused variable in RemoteRequest.java
- RemoteRequestRetry keeps trying even though replicator is shutting down. So Check requestExecutor status before retry.
- Added `shutdownAndAwaitTermination(ExecutorService, long)` for more flexibility