### PR TITLE
Fixed #538 - ReplicationTest failure on Jenkins

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1222,9 +1222,9 @@ public final class Database {
             // wait till all replicator stopped
             for (CountDownLatch latch : latches) {
                 try {
-                    boolean success = latch.await(20, TimeUnit.SECONDS);
+                    boolean success = latch.await(Replication.DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN, TimeUnit.SECONDS);
                     if (!success) {
-                        Log.w(Log.TAG_DATABASE, "Replicator could not stop in 20 second.");
+                        Log.w(Log.TAG_DATABASE, "Replicator could not stop in " + Replication.DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN + " second.");
                     }
                 } catch (Exception e) {
                     Log.w(Log.TAG_DATABASE, e.getMessage());

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -788,6 +788,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     // we told the change tracker to go offline ..
                     Log.d(Log.TAG_SYNC, "Change tracker stopped because we are going offline");
                 }
+                else if(stateMachine.isInState(ReplicationState.STOPPING) ||
+                        stateMachine.isInState(ReplicationState.STOPPED)){
+                    Log.d(Log.TAG_SYNC, "Change tracker stopped because replicator is stopping or stopped.");
+                }
                 else {
                     // otherwise, try to restart the change tracker, since it should
                     // always be running in continuous replications

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -46,6 +46,8 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      */
     public static final String REPLICATOR_DATABASE_NAME = "_replicator";
 
+    public static final long DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN = 60; // 60 sec
+
     /**
      * Options for what metadata to include in document bodies
      */

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -281,7 +281,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
         // shutdown ScheduledExecutorService. Without shutdown, cause thread leak
         if (remoteRequestExecutor != null && !remoteRequestExecutor.isShutdown()) {
             // Note: Time to wait is set 60 sec because RemoteRequest's socket timeout is set 60 seconds.
-            Utils.shutdownAndAwaitTermination(remoteRequestExecutor, 60);
+            Utils.shutdownAndAwaitTermination(remoteRequestExecutor, Replication.DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN);
         }
     }
 


### PR DESCRIPTION
- In log, replicator is stopping, but ChangeTracker is retrying. It causes thread to a live for a while after shutting down.
- Define default maximum timeout to shutdown for replicator.
- Database waits default maximum timeout to shutdown for replicator