### PR TITLE
Fixed #453 LiveQuery should re-run query from scratch after options are ...

### DIFF
--- a/src/main/java/com/couchbase/lite/LiveQuery.java
+++ b/src/main/java/com/couchbase/lite/LiveQuery.java
@@ -6,7 +6,6 @@ import com.couchbase.lite.util.Log;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -355,10 +354,19 @@ public final class LiveQuery extends Query implements Database.ChangeListener {
         update();
     }
 
+    /**
+     * @exclude
+     */
     @InterfaceAudience.Private
     private synchronized void setRows(QueryEnumerator queryEnumerator) {
         rows = queryEnumerator;
     }
 
-
+    /**
+     *
+     */
+    @InterfaceAudience.Public
+    public void queryOptionsChanged() {
+        this.update();
+    }
 }


### PR DESCRIPTION
...changed

- Ported iOS codes from https://github.com/couchbase/couchbase-lite-ios/commit/cffaf9b864c9172f1458d5d9c5cb56f17a75f918
- Added queryOptionsChanged() method into LiveQuery.java
- iOS version has more code changes, but they are currently not applicable for CBL Java Core