### PR TITLE
UnsavedRevision: Preserve insertion order.

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -42,6 +42,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.Object;
+import java.lang.String;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -53,6 +55,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1576,7 +1579,7 @@ public final class Database {
             revsInfo = new ArrayList<Object>();
             List<RevisionInternal> revHistoryFull = getRevisionHistory(rev);
             for (RevisionInternal historicalRev : revHistoryFull) {
-                Map<String,Object> revHistoryItem = new HashMap<String,Object>();
+                Map<String,Object> revHistoryItem = new LinkedHashMap<String,Object>();
                 String status = "available";
                 if(historicalRev.isDeleted()) {
                     status = "deleted";
@@ -1605,7 +1608,7 @@ public final class Database {
             }
         }
 
-        Map<String,Object> result = new HashMap<String,Object>();
+        Map<String,Object> result = new LinkedHashMap<String, Object>();
         result.put("_id", docId);
         result.put("_rev", revId);
         if(rev.isDeleted()) {
@@ -3039,12 +3042,12 @@ public final class Database {
             if (revPos > 0 && revPos < minRevPos && (stub == null)) {
                 // Strip this attachment's body. First make its dictionary mutable:
                 if (editedProperties == null) {
-                    editedProperties = new HashMap<String,Object>(properties);
-                    editedAttachments = new HashMap<String,Object>(attachments);
+                    editedProperties = new LinkedHashMap<String, Object>(properties);
+                    editedAttachments = new LinkedHashMap<String,Object>(attachments);
                     editedProperties.put("_attachments", editedAttachments);
                 }
                 // ...then remove the 'data' and 'follows' key:
-                Map<String,Object> editedAttachment = new HashMap<String,Object>(attachment);
+                Map<String,Object> editedAttachment = new LinkedHashMap<String,Object>(attachment);
                 editedAttachment.remove("data");
                 editedAttachment.remove("follows");
                 editedAttachment.put("stub", true);
@@ -3065,7 +3068,7 @@ public final class Database {
         rev.mutateAttachments(new CollectionUtils.Functor<Map<String, Object>, Map<String, Object>>() {
             public Map<String, Object> invoke(Map<String, Object> attachment) {
                 if (attachment.containsKey("follows") || attachment.containsKey("data")) {
-                    Map<String, Object> editedAttachment = new HashMap<String, Object>(attachment);
+                    Map<String, Object> editedAttachment = new LinkedHashMap<String, Object>(attachment);
                     editedAttachment.remove("follows");
                     editedAttachment.remove("data");
                     editedAttachment.put("stub",true);
@@ -3109,7 +3112,7 @@ public final class Database {
                 }
 
                 // Need to modify attachment entry:
-                Map<String, Object> editedAttachment = new HashMap<String, Object>(attachment);
+                Map<String, Object> editedAttachment = new LinkedHashMap<String, Object>(attachment);
                 editedAttachment.remove("data");
                 if (stubItOut) {
                     // ...then remove the 'data' and 'follows' key:
@@ -3146,7 +3149,7 @@ public final class Database {
                     return null;
                 }
 
-                Map<String, Object> editedAttachment = new HashMap<String, Object>(attachment);
+                Map<String, Object> editedAttachment = new LinkedHashMap<String, Object>(attachment);
                 editedAttachment.remove("follows");
                 editedAttachment.put("data",Base64.encodeBytes(fileData));
                 return editedAttachment;
@@ -3258,7 +3261,7 @@ public final class Database {
                 rememberAttachmentWritersForDigests(blobsByDigest);
 
                 String encodingName = (encoding == AttachmentInternal.AttachmentEncoding.AttachmentEncodingGZIP) ? "gzip" : null;
-                Map<String,Object> dict = new HashMap<String, Object>();
+                Map<String,Object> dict = new LinkedHashMap<String, Object>();
 
                 dict.put("digest", digest);
                 dict.put("length", body.getLength());
@@ -3539,8 +3542,9 @@ public final class Database {
                 "_replication_state_time");
 
         // Don't allow any "_"-prefixed keys. Known ones we'll ignore, unknown ones are an error.
-        Map<String,Object> properties = new HashMap<String,Object>(origProps.size());
-        for (String key : origProps.keySet()) {
+        Map<String,Object> properties = new LinkedHashMap<String,Object>(origProps.size());
+        for (Map.Entry<String, Object> entry : origProps.entrySet()) {
+            String key = entry.getKey();
             boolean shouldAdd = false;
             if(key.startsWith("_")) {
                 if(!KNOWN_SPECIAL_KEYS.contains(key)) {
@@ -3554,7 +3558,7 @@ public final class Database {
                 shouldAdd = true;
             }
             if (shouldAdd) {
-                properties.put(key, origProps.get(key));
+                properties.put(key, entry.getValue());
             }
         }
 
@@ -4020,7 +4024,7 @@ public final class Database {
             return new HashMap<String, AttachmentInternal>();
         }
 
-        Map<String, AttachmentInternal> attachments = new HashMap<String, AttachmentInternal>();
+        Map<String, AttachmentInternal> attachments = new LinkedHashMap<String, AttachmentInternal>();
         for (String name : revAttachments.keySet()) {
             Map<String, Object> attachInfo = (Map<String, Object>) revAttachments.get(name);
             String contentType = (String) attachInfo.get("content_type");

--- a/src/main/java/com/couchbase/lite/UnsavedRevision.java
+++ b/src/main/java/com/couchbase/lite/UnsavedRevision.java
@@ -6,8 +6,8 @@ import com.couchbase.lite.util.Log;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,14 +42,14 @@ public final class UnsavedRevision extends Revision {
         }
 
         if (parentRevisionProperties == null) {
-            properties = new HashMap<String, Object>();
+            properties = new LinkedHashMap<String, Object>();
             properties.put("_id", document.getId());
             if (parentRevID != null) {
                 properties.put("_rev", parentRevID);
             }
         }
         else {
-            properties = new HashMap<String, Object>(parentRevisionProperties);
+            properties = new LinkedHashMap<String, Object>(parentRevisionProperties);
         }
 
     }
@@ -130,11 +130,12 @@ public final class UnsavedRevision extends Revision {
      */
     @InterfaceAudience.Public
     public void setUserProperties(Map<String,Object> userProperties) {
-        Map<String, Object> newProps = new HashMap<String, Object>();
+        Map<String, Object> newProps = new LinkedHashMap<String, Object>();
         newProps.putAll(userProperties);
-        for (String key : properties.keySet()) {
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            String key = entry.getKey();
             if (key.startsWith("_")) {
-                newProps.put(key, properties.get(key));  // Preserve metadata properties
+                newProps.put(key, entry.getValue());  // Preserve metadata properties
             }
         }
         properties = newProps;
@@ -198,7 +199,7 @@ public final class UnsavedRevision extends Revision {
     public List<SavedRevision> getRevisionHistory() throws CouchbaseLiteException {
         // (Don't include self in the array, because this revision doesn't really exist yet)
         SavedRevision parent = getParent();
-        return parent != null ? parent.getRevisionHistory() : new ArrayList<SavedRevision>();
+        return parent != null ? parent.getRevisionHistory() : Collections.<SavedRevision>emptyList();
     }
 
     /**
@@ -211,7 +212,7 @@ public final class UnsavedRevision extends Revision {
     /* package */ void addAttachment(Attachment attachment, String name) {
         Map<String, Object> attachments =  (Map<String, Object>) properties.get("_attachments");
         if (attachments == null) {
-            attachments = new HashMap<String, Object>();
+            attachments = new LinkedHashMap<String, Object>();
         }
         attachments.put(name, attachment);
         properties.put("_attachments", attachments);
@@ -220,6 +221,4 @@ public final class UnsavedRevision extends Revision {
             attachment.setRevision(this);
         }
     }
-
-
 }

--- a/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
@@ -19,7 +19,7 @@ package com.couchbase.lite.internal;
 
 import com.couchbase.lite.util.CollectionUtils;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -56,21 +56,14 @@ public class RevisionInternal {
     }
 
     public Map<String, Object> getProperties() {
-        Map<String, Object> result = null;
         if (body != null) {
-            Map<String, Object> prop;
             try {
-                prop = body.getProperties();
+                return body.getProperties();
             } catch (IllegalStateException e) {
                 // handle when both object and json are null for this body
-                return null;
             }
-            if (result == null) {
-                result = new HashMap<String, Object>();
-            }
-            result.putAll(prop);
         }
-        return result;
+        return null;
     }
 
     public Object getPropertyForKey(String key) {
@@ -160,7 +153,7 @@ public class RevisionInternal {
         assert ((this.docId == null) || (this.docId.equals(docId)));
         RevisionInternal result = new RevisionInternal(docId, revId, deleted);
         Map<String, Object> unmodifiableProperties = getProperties();
-        Map<String, Object> properties = new HashMap<String, Object>();
+        Map<String, Object> properties = new LinkedHashMap<String, Object>();
         if (unmodifiableProperties != null) {
             properties.putAll(unmodifiableProperties);
         }
@@ -278,7 +271,7 @@ public class RevisionInternal {
             if(attachments != null) {
                 for (String name : attachments.keySet()) {
 
-                    Map<String, Object> attachment = new HashMap<String, Object>((Map<String, Object>) attachments.get(name));
+                    Map<String, Object> attachment = new LinkedHashMap<String, Object>((Map<String, Object>) attachments.get(name));
                     attachment.put("name", name);
                     Map<String, Object> editedAttachment = functor.invoke(attachment);
                     if (editedAttachment == null) {
@@ -287,8 +280,8 @@ public class RevisionInternal {
                     if (editedAttachment != attachment) {
                         if (editedProperties == null) {
                             // Make the document properties and _attachments dictionary mutable:
-                            editedProperties = new HashMap<String, Object>(properties);
-                            editedAttachments = new HashMap<String, Object>(attachments);
+                            editedProperties = new LinkedHashMap<String, Object>(properties);
+                            editedAttachments = new LinkedHashMap<String, Object>(attachments);
                             editedProperties.put("_attachments", editedAttachments);
                         }
                         editedAttachment.remove("name");
@@ -308,6 +301,6 @@ public class RevisionInternal {
         if (getProperties() != null && getProperties().containsKey("_attachments")) {
             return (Map<String, Object>) getProperties().get("_attachments");
         }
-        return new HashMap<String, Object>();
+        return new LinkedHashMap<String, Object>();
     }
 }


### PR DESCRIPTION
Preserve insertion order in the JSON by using LinkedHashMap's.
This is also used by Jackson [1] and the .NET port, it seems [2].

Altough not really a necessity, preserving insertion order is a nice to have,
helpeful when someone wants to compare multiple JSON documents.

[1]: http://wiki.fasterxml.com/JacksonDataBinding#line-54
[2]: https://github.com/couchbase/couchbase-lite-net/blob/master/src/Couchbase.Lite.Shared/Sharpen/LinkedHashMap.cs