### PR TITLE
createRevision() does not throw checked exceptions

### DIFF
--- a/src/main/java/com/couchbase/lite/SavedRevision.java
+++ b/src/main/java/com/couchbase/lite/SavedRevision.java
@@ -95,12 +95,10 @@ public final class SavedRevision extends Revision {
     /**
      * Creates a new mutable child revision whose properties and attachments are initially identical
      * to this one's, which you can modify and then save.
-     * @return
      */
     @InterfaceAudience.Public
-    public UnsavedRevision createRevision() throws CouchbaseLiteException {
-        UnsavedRevision newRevision = new UnsavedRevision(document, this);
-        return newRevision;
+    public UnsavedRevision createRevision() {
+        return new UnsavedRevision(document, this);
     }
 
     /**


### PR DESCRIPTION
It does not throw in Document and so it shouldn't throw in SavedRevision.