### PR TITLE
BlobStoreWriter: Throw IOExceptions.

### DIFF
--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -244,7 +244,11 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
             jsonBuffer.append(data, off, len);
         }
         else {
-            curAttachment.appendData(data, off, len);
+            try {
+                curAttachment.appendData(data, off, len);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to append data", e);
+            }
         }
     }
 
@@ -254,7 +258,11 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
             parseJsonBuffer();
         }
         else {
-            curAttachment.finish();
+            try {
+                curAttachment.finish();
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to finish attachment", e);
+            }
             String md5String = curAttachment.mD5DigestString();
             attachmentsByMd5Digest.put(md5String, curAttachment);
             curAttachment = null;


### PR DESCRIPTION
Instead of throwing an unchecked exception and ignoring the close on the
output file, throw checked IOExceptions.

We should consider an fsync before closing the outputstream to get a better
consistency guarantee.

With this commit, when saving an attachment fails on UnsavedRevison#save
a CBLException is thrown with STATUS_ATTACHMENT_ERROR.

MultipartDocumentReader continues to throw unchecked exceptions.