### PR TITLE
Encode userinfo in BasicAuthenticator.

### DIFF
--- a/src/main/java/com/couchbase/lite/auth/BasicAuthenticator.java
+++ b/src/main/java/com/couchbase/lite/auth/BasicAuthenticator.java
@@ -1,5 +1,7 @@
 package com.couchbase.lite.auth;
 
+import com.couchbase.lite.util.URIUtils;
+
 import java.net.URL;
 import java.util.Map;
 
@@ -25,7 +27,7 @@ public class BasicAuthenticator extends AuthenticatorImpl {
     @Override
     public String authUserInfo() {
         if (this.username != null && this.password != null) {
-            return this.username + ":" + this.password;
+            return URIUtils.encode(this.username) + ":" + URIUtils.encode(this.password);
         }
         return super.authUserInfo();
     }

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -275,24 +275,18 @@ public class ChangeTracker implements Runnable {
             addRequestHeaders(request);
 
             // Perform BASIC Authentication if needed
-            boolean isUrlBasedUserInfo = false;
-
             // If the URL contains user info AND if this a DefaultHttpClient then preemptively set the auth credentials
             String userInfo = url.getUserInfo();
-            if (userInfo != null) {
-                isUrlBasedUserInfo = true;
-            } else {
-                if (authenticator != null) {
-                    AuthenticatorImpl auth = (AuthenticatorImpl) authenticator;
-                    userInfo = auth.authUserInfo();
-                }
+            if (userInfo == null && authenticator != null) {
+                AuthenticatorImpl auth = (AuthenticatorImpl) authenticator;
+                userInfo = auth.authUserInfo();
             }
 
             if (userInfo != null) {
                 if (userInfo.contains(":") && !userInfo.trim().equals(":")) {
                     String[] userInfoElements = userInfo.split(":");
-                    String username = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[0]) : userInfoElements[0];
-                    String password = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[1]) : userInfoElements[1];
+                    String username = URIUtils.decode(userInfoElements[0]);
+                    String password = URIUtils.decode(userInfoElements[1]);
                     final Credentials credentials = new UsernamePasswordCredentials(username, password);
 
                     if (httpClient instanceof DefaultHttpClient) {

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -251,23 +251,18 @@ public class RemoteRequest implements Runnable {
     }
 
     protected void preemptivelySetAuthCredentials(HttpClient httpClient) {
-        boolean isUrlBasedUserInfo = false;
 
         String userInfo = url.getUserInfo();
-        if (userInfo != null) {
-            isUrlBasedUserInfo = true;
-        } else {
-            if (authenticator != null) {
-                AuthenticatorImpl auth = (AuthenticatorImpl) authenticator;
-                userInfo = auth.authUserInfo();
-            }
+        if (userInfo == null && authenticator != null) {
+            AuthenticatorImpl auth = (AuthenticatorImpl) authenticator;
+            userInfo = auth.authUserInfo();
         }
 
         if (userInfo != null) {
             if (userInfo.contains(":") && !userInfo.trim().equals(":")) {
                 String[] userInfoElements = userInfo.split(":");
-                String username = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[0]): userInfoElements[0];
-                String password = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[1]): userInfoElements[1];
+                String username = URIUtils.decode(userInfoElements[0]);
+                String password = URIUtils.decode(userInfoElements[1]);
                 final Credentials credentials = new UsernamePasswordCredentials(username, password);
 
                 if (httpClient instanceof DefaultHttpClient) {


### PR DESCRIPTION
Basic authentication was broken if the username contained a ':'.