### PR TITLE
Fix authinfo with non-ASCII passwords.

### DIFF
--- a/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
+++ b/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
@@ -3,6 +3,7 @@ package com.couchbase.lite.support;
 import com.couchbase.lite.Database;
 import com.couchbase.lite.internal.InterfaceAudience;
 
+import org.apache.http.auth.params.AuthPNames;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ClientConnectionManager;
@@ -15,6 +16,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.protocol.HTTP;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -80,6 +82,7 @@ public class CouchbaseLiteHttpClientFactory implements HttpClientFactory {
 
         if (basicHttpParams == null) {
             basicHttpParams = new BasicHttpParams();
+            basicHttpParams.setParameter(AuthPNames.CREDENTIAL_CHARSET, HTTP.UTF_8);
             HttpConnectionParams.setConnectionTimeout(basicHttpParams, DEFAULT_CONNECTION_TIMEOUT_SECONDS * 1000);
             HttpConnectionParams.setSoTimeout(basicHttpParams, DEFAULT_SO_TIMEOUT_SECONDS * 1000);
         }


### PR DESCRIPTION
Fixes couchbase/couchbase-lite-android#382

I tested this with the performance.Test7_PullReplication testcases and wireshark.
To test this either [percent encode](http://coderstoolbox.net/string/) the username and password (where needed) or use couchbase/couchbase-lite-android#582.

I used wireshark to check the response for the GET /db/_local/uuid, because the test does not fail if unauthorized.

Tested on rcouch using with 七乃又直ந்த as the username, and ؤلمن:يстекло as the password. Of course the account must be created beforehand.