### PR TITLE
Allow allDocumentsQuery().toLiveQuery().

### DIFF
--- a/src/main/java/com/couchbase/lite/LiveQuery.java
+++ b/src/main/java/com/couchbase/lite/LiveQuery.java
@@ -6,6 +6,7 @@ import com.couchbase.lite.util.Log;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -62,25 +63,11 @@ public final class LiveQuery extends Query implements Database.ChangeListener {
     @Override
     @InterfaceAudience.Public
     public QueryEnumerator run() throws CouchbaseLiteException {
-
-        while (true) {
-            try {
-                waitForRows();
-                break;
-            } catch (Exception e) {
-                if (e instanceof CancellationException) {
-                    continue;
-                } else {
-                    lastError = e;
-                    throw new CouchbaseLiteException(e, Status.INTERNAL_SERVER_ERROR);
-                }
-            }
-        }
+        waitForRows();
 
         if (rows == null) {
             return null;
-        }
-        else {
+        } else {
             // Have to return a copy because the enumeration has to start at item #0 every time
             return new QueryEnumerator(rows);
         }
@@ -162,16 +149,13 @@ public final class LiveQuery extends Query implements Database.ChangeListener {
             try {
                 queryFuture.get();
                 break;
+            } catch (InterruptedException e) {
+                continue;
             } catch (Exception e) {
-                if (e instanceof CancellationException) {
-                    continue;
-                } else {
-                    lastError = e;
-                    throw new CouchbaseLiteException(e, Status.INTERNAL_SERVER_ERROR);
-                }
+                lastError = e;
+                throw new CouchbaseLiteException(e, Status.INTERNAL_SERVER_ERROR);
             }
         }
-
     }
 
     /**
@@ -254,10 +238,6 @@ public final class LiveQuery extends Query implements Database.ChangeListener {
     /* package */ void update() {
         Log.v(Log.TAG_QUERY, "%s: update() called.", this);
 
-        if (getView() == null) {
-            throw new IllegalStateException("Cannot start LiveQuery when view is null");
-        }
-
         if (runningState.get() == false) {
             Log.d(Log.TAG_QUERY, "%s: update() called, but running state == false.  Ignoring.", this);
             return;
@@ -313,6 +293,9 @@ public final class LiveQuery extends Query implements Database.ChangeListener {
      * some of the recently added items.
      */
     private Future rerunUpdateAfterQueryFinishes(final Future queryFutureInProgress) {
+        if (queryFutureInProgress == null) {
+            throw new NullPointerException();
+        }
         return getDatabase().getManager().runAsync(new Runnable() {
             @Override
             public void run() {
@@ -322,24 +305,25 @@ public final class LiveQuery extends Query implements Database.ChangeListener {
                     return;
                 }
 
-                if (queryFutureInProgress != null) {
+                while (true) {
                     try {
                         queryFutureInProgress.get();
-
-                        if (runningState.get() == false) {
-                            Log.v(Log.TAG_QUERY, "%s: queryFutureInProgress.get() done, but running state == false.", this);
-                            return;
-                        }
-
-                        update();
-                    } catch (Exception e) {
-                        if (e instanceof CancellationException) {
-                            // can safely ignore these
-                        } else {
-                            Log.e(Log.TAG_QUERY, "Got exception waiting for queryFutureInProgress to finish", e);
-                        }
+                    } catch (InterruptedException e) {
+                        continue;
+                    } catch (CancellationException e) {
+                        // can safely ignore these
+                    } catch (ExecutionException e) {
+                        Log.e(Log.TAG_QUERY, "Got exception waiting for queryFutureInProgress to finish", e);
                     }
+                    break;
                 }
+
+                if (runningState.get() == false) {
+                    Log.v(Log.TAG_QUERY, "%s: queryFutureInProgress.get() done, but running state == false.", this);
+                    return;
+                }
+
+                update();
             }
         });
     }

--- a/src/main/java/com/couchbase/lite/Query.java
+++ b/src/main/java/com/couchbase/lite/Query.java
@@ -402,9 +402,6 @@ public class Query {
      */
     @InterfaceAudience.Public
     public LiveQuery toLiveQuery() {
-        if (view == null) {
-            throw new IllegalStateException("Cannot convert a Query to LiveQuery if the view is null");
-        }
         return new LiveQuery(this);
     }
 
@@ -442,7 +439,7 @@ public class Query {
                         throw new IllegalStateException("The database has been closed.");
                     }
 
-                    String viewName = view.getName();
+                    String viewName = (view != null) ? view.getName() : null;
                     QueryOptions options = getQueryOptions();
                     List<Long> outSequence = new ArrayList<Long>();
                     List<QueryRow> rows = database.queryViewNamed(viewName, options, outSequence);


### PR DESCRIPTION
Fixes couchbase/couchbase-lite-android#237
Also fixes an infinite loop in waitForRows(), if another thread calls stop().