### PR TITLE
Fixed #456

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -217,7 +217,7 @@ public class ChangeTracker implements Runnable {
 
     @Override
     public void run() {
-        Log.e(Log.TAG_CHANGE_TRACKER, "Thread id => " + Thread.currentThread().getId());
+        Log.d(Log.TAG_CHANGE_TRACKER, "Thread id => " + Thread.currentThread().getId());
         try {
             runLoop();
         } finally {
@@ -357,7 +357,7 @@ public class ChangeTracker implements Runnable {
                                 backoff.resetBackoff();
                                 continue;
                             } else {
-                                Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker calling stop (LongPoll)", this);
+                                Log.d(Log.TAG_CHANGE_TRACKER, "%s: Change tracker calling stop (LongPoll)", this);
                                 client.changeTrackerFinished(this);
                                 break;
                             }
@@ -389,7 +389,7 @@ public class ChangeTracker implements Runnable {
                             if (isContinuous()) {  // if enclosing replication is continuous
                                 mode = ChangeTrackerMode.LongPoll;
                             } else {
-                                Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker calling stop (OneShot)", this);
+                                Log.d(Log.TAG_CHANGE_TRACKER, "%s: Change tracker calling stop (OneShot)", this);
                                 client.changeTrackerFinished(this);
                                 break;
                             }
@@ -496,10 +496,10 @@ public class ChangeTracker implements Runnable {
     private void stopped() {
         Log.d(Log.TAG_CHANGE_TRACKER, "%s: Change tracker in stopped()", this);
         if (client != null) {
-            Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker calling changeTrackerStopped, client: %s", this, client);
+            Log.d(Log.TAG_CHANGE_TRACKER, "%s: Change tracker calling changeTrackerStopped, client: %s", this, client);
             client.changeTrackerStopped(ChangeTracker.this);
         } else {
-            Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker not calling changeTrackerStopped, client == null", this);
+            Log.d(Log.TAG_CHANGE_TRACKER, "%s: Change tracker not calling changeTrackerStopped, client == null", this);
         }
         client = null;
         running = false; // in case stop() method was not called to stop

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -859,8 +859,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         if (type == EventType.PUT || type == EventType.ADD) {
             if (isContinuous()) {
                 if (!queue.isEmpty()) {
-                    fireTrigger(ReplicationTrigger.RESUME);
-                    waitForPendingFuturesWithNewThread();
+                    if (!waitingForPendingFutures) {
+                        fireTrigger(ReplicationTrigger.RESUME);
+                        waitForPendingFuturesWithNewThread();
+                    }
                 }
             }
         }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -67,6 +67,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     protected int httpConnectionCount;
     protected Batcher<RevisionInternal> downloadsToInsert;
 
+    // for waitingPendingFutures
+    protected boolean waitingForPendingFutures = false;
+    protected Object lockWaitForPendingFutures = new Object();
+
     public PullerInternal(Database db, URL remote, HttpClientFactory clientFactory, ScheduledExecutorService workExecutor, Replication.Lifecycle lifecycle, Replication parentReplication) {
         super(db, remote, clientFactory, workExecutor, lifecycle, parentReplication);
     }
@@ -115,10 +119,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         // it will switch to longpoll later.
         changeTrackerMode = ChangeTracker.ChangeTrackerMode.OneShot;
 
-        Log.w(Log.TAG_SYNC, "%s: starting ChangeTracker with since=%s mode=%s", this, lastSequence, changeTrackerMode);
+        Log.d(Log.TAG_SYNC, "%s: starting ChangeTracker with since=%s mode=%s", this, lastSequence, changeTrackerMode);
         changeTracker = new ChangeTracker(remote, changeTrackerMode, true, lastSequence, this);
         changeTracker.setAuthenticator(getAuthenticator());
-        Log.w(Log.TAG_SYNC, "%s: started ChangeTracker %s", this, changeTracker);
+        Log.d(Log.TAG_SYNC, "%s: started ChangeTracker %s", this, changeTracker);
 
         if (filterName != null) {
             changeTracker.setFilterName(filterName);
@@ -490,7 +494,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     @InterfaceAudience.Private
     public void insertDownloads(List<RevisionInternal> downloads) {
 
-        Log.i(Log.TAG_SYNC, this + " inserting " + downloads.size() + " revisions...");
+        Log.d(Log.TAG_SYNC, this + " inserting " + downloads.size() + " revisions...");
         long time = System.currentTimeMillis();
         Collections.sort(downloads, getRevisionListComparator());
 
@@ -836,7 +840,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     @Override
     public void changeTrackerCaughtUp() {
-        Log.e(Log.TAG_SYNC, "changeTrackerCaughtUp");
+        Log.d(Log.TAG_SYNC, "changeTrackerCaughtUp");
         // for continuous replications, once the change tracker is caught up, we
         // should try to go into the idle state.
         if (isContinuous()) {
@@ -856,15 +860,18 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
      */
     @Override
     public void changed(EventType type, Object o, BlockingQueue queue) {
-        if (type == EventType.PUT || type == EventType.ADD) {
-            if (isContinuous()) {
-                if (!queue.isEmpty()) {
-                    if (!waitingForPendingFutures) {
-                        fireTrigger(ReplicationTrigger.RESUME);
-                        waitForPendingFuturesWithNewThread();
-                    }
+        if ((type == EventType.PUT || type == EventType.ADD) &&
+                isContinuous() &&
+                !queue.isEmpty()) {
+
+            synchronized (lockWaitForPendingFutures) {
+                if (waitingForPendingFutures) {
+                    return;
                 }
             }
+
+            fireTrigger(ReplicationTrigger.RESUME);
+            waitForPendingFuturesWithNewThread();
         }
     }
 
@@ -900,9 +907,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             }
         }).start();
     }
-
-    protected boolean waitingForPendingFutures = false;
-    protected Object lockWaitForPendingFutures = new Object();
 
     public void waitForPendingFutures() {
         synchronized (lockWaitForPendingFutures) {
@@ -947,7 +951,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             }
 
             // wait for pending featurs completed
-            Log.e(Log.TAG_SYNC, "waitPendingFuturesCompleted()");
+            Log.d(Log.TAG_SYNC, "waitPendingFuturesCompleted()");
             waitPendingFuturesCompleted();
 
             // wait for downloadToInsert batcher completed

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -183,7 +183,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
      * Fire a trigger to the state machine
      */
     protected void fireTrigger(final ReplicationTrigger trigger) {
-        Log.w(Log.TAG_SYNC, "[fireTrigger()] => " + trigger);
+        Log.d(Log.TAG_SYNC, "[fireTrigger()] => " + trigger);
         // All state machine triggers need to happen on the replicator thread
         synchronized (workExecutor) {
             if (!workExecutor.isShutdown()) {
@@ -690,7 +690,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
         }
 
         final String checkpointID = remoteCheckpointDocID;
-        Log.i(Log.TAG_SYNC, "%s: start put remote _local document.  checkpointID: %s body: %s", this, checkpointID, body);
+        Log.d(Log.TAG_SYNC, "%s: start put remote _local document.  checkpointID: %s body: %s", this, checkpointID, body);
         Future future = sendAsyncRequest("PUT", "/_local/" + checkpointID, body, new RemoteRequestCompletionBlock() {
 
             @Override
@@ -1151,7 +1151,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                 // But, for Core Java, some of codes wait IDLE state. So this is reason to wait till
                 // state becomes IDLE.
                 if(Utils.isPermanentError(error) && isContinuous()){
-                    Log.e(Log.TAG_SYNC, "IDLE: triggerStop() " + error.toString());
+                    Log.d(Log.TAG_SYNC, "IDLE: triggerStop() " + error.toString());
                     triggerStop();
                 }
             }


### PR DESCRIPTION
- Current code tries to set Replicator state from RUNNING to RUNNING, also it calls `waitForPendingFuturesWithNewThread()` which creates a thread. They are not necessary to be called if replicator's state is RUNNING or `waitingForPendingFutures` is true.
- By checking `waitingForPendingFutures`, tries to avoid above unnecessary stuff.