### PR TITLE
Fix get attachment stream fails on UnsavedRevision

### DIFF
--- a/src/main/java/com/couchbase/lite/Attachment.java
+++ b/src/main/java/com/couchbase/lite/Attachment.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 /**
  * A Couchbase Lite Document Attachment.
@@ -132,6 +133,16 @@ public final class Attachment {
             }
             Attachment attachment = db.getAttachmentForSequence(sequence, this.name);
             body = attachment.getContent();
+            if (attachment.getGZipped()) {
+                // Client does not expect a gzipped stream.
+                // Only Router handles gzipped streams and uses getAttachmentForSequence directly.
+                try {
+                    body = new GZIPInputStream(body);
+                } catch (IOException e) {
+                    throw new CouchbaseLiteException(e.getMessage(), Status.STATUS_ATTACHMENT_ERROR);
+                }
+            }
+            gzipped = false;
             return body;
         }
     }

--- a/src/main/java/com/couchbase/lite/Revision.java
+++ b/src/main/java/com/couchbase/lite/Revision.java
@@ -17,11 +17,6 @@ import java.util.Map;
  */
 public abstract class Revision {
 
-    /**re
-     * The sequence number of this revision.
-     */
-    protected long sequence;
-
     /**
      * The document this is a revision of
      */
@@ -67,7 +62,7 @@ public abstract class Revision {
     }
 
     /**
-     * Gets the Revision's id.
+     * Gets the Revision's id. In the case of an unsaved revision, may return null.
      */
     @InterfaceAudience.Public
     public abstract String getId();
@@ -192,6 +187,12 @@ public abstract class Revision {
     public abstract String getParentId();
 
     /**
+     * @exclude
+     */
+    @InterfaceAudience.Private
+    /* package */ abstract long getParentSequence();
+
+    /**
      * Returns the history of this document as an array of CBLRevisions, in forward order.
      * Older revisions are NOT guaranteed to have their properties available.
      *
@@ -274,17 +275,7 @@ public abstract class Revision {
      * @exclude
      */
     @InterfaceAudience.Private
-    /* package */ void setSequence(long sequence) {
-        this.sequence = sequence;
-    }
-
-    /**
-     * @exclude
-     */
-    @InterfaceAudience.Private
-    /* package */ long getSequence() {
-        return sequence;
-    }
+    /* package */ abstract long getSequence();
 
     /**
      * Generation number: 1 for a new document, 2 for the 2nd revision, ...

--- a/src/main/java/com/couchbase/lite/SavedRevision.java
+++ b/src/main/java/com/couchbase/lite/SavedRevision.java
@@ -170,6 +170,13 @@ public final class SavedRevision extends Revision {
     }
 
     @Override
+    @InterfaceAudience.Private
+    /* package */ long getParentSequence() {
+        SavedRevision parent = getParent();
+        return (parent != null) ? parent.getSequence() : 0L;
+    }
+
+    @Override
     @InterfaceAudience.Public
     public long getSequence() {
         long sequence = revisionInternal.getSequence();

--- a/src/main/java/com/couchbase/lite/UnsavedRevision.java
+++ b/src/main/java/com/couchbase/lite/UnsavedRevision.java
@@ -16,6 +16,7 @@ import java.util.Map;
  */
 public final class UnsavedRevision extends Revision {
 
+    private final long parentSequence;
     private Map<String, Object> properties;
 
     /**
@@ -29,8 +30,10 @@ public final class UnsavedRevision extends Revision {
 
         if (parentRevision == null) {
             parentRevID = null;
+            parentSequence = 0L;
         } else {
             parentRevID = parentRevision.getId();
+            parentSequence = parentRevision.getSequence();
         }
 
         Map<String, Object> parentRevisionProperties;
@@ -67,14 +70,16 @@ public final class UnsavedRevision extends Revision {
         }
     }
 
-    /**
-     * Get the id of the owning document.  In the case of an unsaved revision, may return null.
-     * @return
-     */
     @Override
     @InterfaceAudience.Public
     public String getId() {
         return null;
+    }
+
+    @Override
+    @InterfaceAudience.Private
+    /* package */ long getSequence() {
+        return 0L;
     }
 
     /**
@@ -191,6 +196,12 @@ public final class UnsavedRevision extends Revision {
     @InterfaceAudience.Public
     public String getParentId() {
         return parentRevID;
+    }
+
+    @Override
+    @InterfaceAudience.Private
+    /* package */ long getParentSequence() {
+        return parentSequence;
     }
 
     @Override


### PR DESCRIPTION
Closes #592.

This introduces a new package protected method getParentSequence().
The alternative was to call getParent().getSequence() which leads to an extra
database query everytime an attachment is retrieved from a non-current revision.