### PR TITLE
Fixed #602 Make / db names work in windows

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -10,7 +10,6 @@ import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.support.Version;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.StreamUtils;
-
 import com.couchbase.lite.util.Utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -417,7 +416,14 @@ public final class Manager {
         if ((name == null) || (name.length() == 0) || Pattern.matches(LEGAL_CHARACTERS, name)) {
             return null;
         }
-        name = name.replace('/', ':');
+        // NOTE: CouchDB allows forward slash as part of database name.
+        //       However, ':' is illegal character on Windows platform.
+        //       For Windows, substitute with period '.'
+        if(isWindows()) {
+            name = name.replace('/', '.');
+        }else{
+            name = name.replace('/', ':');
+        }
         String result = directoryFile.getPath() + File.separator + name + Manager.DATABASE_SUFFIX;
         return result;
     }
@@ -667,6 +673,17 @@ public final class Manager {
     @InterfaceAudience.Private
     protected boolean isAutoMigrateBlobStoreFilename() {
         return this.options.isAutoMigrateBlobStoreFilename();
+    }
+
+
+    private static String OS = System.getProperty("os.name").toLowerCase();
+
+    /**
+     * Check if platform is Windows
+     */
+    @InterfaceAudience.Private
+    public static boolean isWindows() {
+        return (OS.indexOf("win") >= 0);
     }
 }
 

--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -675,14 +675,13 @@ public final class Manager {
         return this.options.isAutoMigrateBlobStoreFilename();
     }
 
-
     private static String OS = System.getProperty("os.name").toLowerCase();
 
     /**
      * Check if platform is Windows
      */
     @InterfaceAudience.Private
-    public static boolean isWindows() {
+    private static boolean isWindows() {
         return (OS.indexOf("win") >= 0);
     }
 }


### PR DESCRIPTION
- Use period "." instead of ":" for Windows platform