### PR TITLE
Fixed #609 - pre-built database

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -284,7 +284,8 @@ public final class Manager {
 
     private void replaceDatabase(String databaseName, InputStream databaseStream, Iterator<Map.Entry<String, InputStream>> attachmentStreams) throws CouchbaseLiteException {
         try {
-            Database database = getDatabase(databaseName);
+            //Database database = getDatabase(databaseName);
+            Database database = getDatabaseWithoutOpening(databaseName, false);
             String dstAttachmentsPath = database.getAttachmentStorePath();
             OutputStream destStream = new FileOutputStream(new File(database.getPath()));
             StreamUtils.copyStream(databaseStream, destStream);


### PR DESCRIPTION
- In replaceDatabase(), create database instance without opening database.
- creates `maps` table and related indexes if `maps` table does not exist
- In stead of delete all rows in maps, drop table and recreate it.