### PR TITLE
Fixed CBL Android 197 gzipped attachment

### DIFF
--- a/src/main/java/com/couchbase/lite/Attachment.java
+++ b/src/main/java/com/couchbase/lite/Attachment.java
@@ -270,6 +270,9 @@ public final class Attachment {
     }
 
     /**
+     * NOTE: getGZipped() can return correct value if Attachment is returned from Database.getAttachmentForSequence(long, String).
+     *       This method should be internal use only.
+     *
      * @exclude
      */
     @InterfaceAudience.Private

--- a/src/main/java/com/couchbase/lite/Attachment.java
+++ b/src/main/java/com/couchbase/lite/Attachment.java
@@ -21,8 +21,8 @@ import com.couchbase.lite.internal.AttachmentInternal;
 import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.util.Log;
 
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Collections;
@@ -132,7 +132,7 @@ public final class Attachment {
                 throw new CouchbaseLiteException(Status.INTERNAL_SERVER_ERROR);
             }
             Attachment attachment = db.getAttachmentForSequence(sequence, this.name);
-            body = attachment.getContent();
+            body = attachment.getBodyIfNew();
             if (attachment.getGZipped()) {
                 // Client does not expect a gzipped stream.
                 // Only Router handles gzipped streams and uses getAttachmentForSequence directly.

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -3159,16 +3159,16 @@ public final class Database {
                 }
 
                 String encodingStr = null;
-                if(encoding!=AttachmentInternal.AttachmentEncoding.AttachmentEncodingNone){
+                if (encoding == AttachmentInternal.AttachmentEncoding.AttachmentEncodingGZIP) {
                     // NOTE: iOS decode if attachment is included int the dict.
                     encodingStr = "gzip";
                 }
 
                 Map<String, Object> attachment = new HashMap<String, Object>();
-                if(!(dataBase64 != null || dataSuppressed)) {
+                if (!(dataBase64 != null || dataSuppressed)) {
                     attachment.put("stub", true);
                 }
-                if(dataBase64 != null) {
+                if (dataBase64 != null) {
                     attachment.put("data", dataBase64);
                 }
                 if (dataSuppressed == true) {
@@ -3177,11 +3177,13 @@ public final class Database {
                 attachment.put("digest", digestString);
                 String contentType = cursor.getString(2);
                 attachment.put("content_type", contentType);
-                if (encodingStr != null)
+                if (encodingStr != null) {
                     attachment.put("encoding", encodingStr);
+                }
                 attachment.put("length", length);
-                if (encodingStr != null && encodedLength >= 0)
+                if (encodingStr != null && encodedLength >= 0) {
                     attachment.put("encoded_length", encodedLength);
+                }
                 attachment.put("revpos", cursor.getInt(6));
 
                 String filename = cursor.getString(0);

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1269,6 +1269,8 @@ public final class Database {
                             "key BLOB NOT NULL, " +
                             "type TEXT, " +
                             "length INTEGER NOT NULL, " +
+                            "encoding INTEGER DEFAULT 0, " +
+                            "encoded_length INTEGER, " +
                             "revpos INTEGER DEFAULT 0); " +
                             "CREATE INDEX attachments_by_sequence on attachments(sequence, filename); " +
                             "CREATE INDEX attachments_sequence ON attachments(sequence); " +
@@ -1297,9 +1299,16 @@ public final class Database {
                                         int revPos = (Integer) attachment.get("revpos");
                                         int length = (Integer) attachment.get("length");
                                         String digest = (String) attachment.get("digest");
+                                        int encodedLength = -1;
+                                        if(attachment.containsKey("encoded_length"))
+                                            encodedLength = (Integer)attachment.get("encoded_length");
+                                        AttachmentInternal.AttachmentEncoding encoding = AttachmentInternal.AttachmentEncoding.AttachmentEncodingNone;
+                                        if(attachment.containsKey("encoding") && attachment.get("encoding").equals("gzip")){
+                                            encoding = AttachmentInternal.AttachmentEncoding.AttachmentEncodingGZIP;
+                                        }
                                         BlobKey key = new BlobKey(digest);
                                         try {
-                                            insertAttachmentForSequenceWithNameAndType(sequence, name, contentType, revPos, key, length);
+                                            insertAttachmentForSequenceWithNameAndType(sequence, name, contentType, revPos, key, length, encoding, encodedLength);
                                         } catch (CouchbaseLiteException e) {
                                             Log.e(Log.TAG_DATABASE, "Attachment information inserstion error: " + name + "=" + attachment.toString(), e);
                                             return false;
@@ -2854,10 +2863,15 @@ public final class Database {
                 attachment.getName(),
                 attachment.getContentType(),
                 attachment.getRevpos(),
-                attachment.getBlobKey());
+                attachment.getBlobKey(),
+                attachment.getLength(),
+                attachment.getEncoding(),
+                attachment.getEncodedLength());
     }
 
     /**
+     * Note: This method is used only from unit tests.
+     *
      * @exclude
      */
     @InterfaceAudience.Private
@@ -2882,16 +2896,28 @@ public final class Database {
      */
     @InterfaceAudience.Private
     public void insertAttachmentForSequenceWithNameAndType(long sequence, String name, String contentType, int revpos, BlobKey key) throws CouchbaseLiteException {
+        insertAttachmentForSequenceWithNameAndType(sequence, name, contentType, revpos, key, key != null ? attachments.getSizeOfBlob(key): -1, AttachmentInternal.AttachmentEncoding.AttachmentEncodingNone, -1);
+    }
+
+    private void insertAttachmentForSequenceWithNameAndType(long sequence, String name, String contentType, int revpos, BlobKey key, long length, AttachmentInternal.AttachmentEncoding encoding, long encodedLength) throws CouchbaseLiteException {
         try {
             ContentValues args = new ContentValues();
             args.put("sequence", sequence);
             args.put("filename", name);
-            if (key != null) {
-                args.put("key", key.getBytes());
-                args.put("length", attachments.getSizeOfBlob(key));
-            }
             args.put("type", contentType);
             args.put("revpos", revpos);
+            if (key != null) {
+                args.put("key", key.getBytes());
+            }
+            if (length >= 0) {
+                args.put("length", length);
+            }
+            if(encoding == AttachmentInternal.AttachmentEncoding.AttachmentEncodingGZIP) {
+                args.put("encoding", encoding.ordinal());
+                if (encodedLength >= 0) {
+                    args.put("encoded_length", encodedLength);
+                }
+            }
             long result = database.insert("attachments", null, args);
             if (result == -1) {
                 String msg = "Insert attachment failed (returned -1)";
@@ -2904,26 +2930,6 @@ public final class Database {
         }
     }
 
-    private void insertAttachmentForSequenceWithNameAndType(long sequence, String name, String contentType, int revpos, BlobKey key, long length) throws CouchbaseLiteException {
-        try {
-            ContentValues args = new ContentValues();
-            args.put("sequence", sequence);
-            args.put("filename", name);
-            args.put("key", key.getBytes());
-            args.put("length", length);
-            args.put("type", contentType);
-            args.put("revpos", revpos);
-            long result = database.insert("attachments", null, args);
-            if (result == -1) {
-                String msg = "Insert attachment failed (returned -1)";
-                Log.e(Database.TAG, msg);
-                throw new CouchbaseLiteException(msg, Status.INTERNAL_SERVER_ERROR);
-            }
-        } catch (SQLException e) {
-            Log.e(Database.TAG, "Error inserting attachment", e);
-            throw new CouchbaseLiteException(e, Status.INTERNAL_SERVER_ERROR);
-        }
-    }
     /**
      * @exclude
      */
@@ -3116,7 +3122,7 @@ public final class Database {
 
         String args[] = { Long.toString(sequence) };
         try {
-            cursor = database.rawQuery("SELECT filename, key, type, length, revpos FROM attachments WHERE sequence=?", args);
+            cursor = database.rawQuery("SELECT filename, key, type, encoding, length, encoded_length, revpos FROM attachments WHERE sequence=?", args);
 
             if(!cursor.moveToNext()) {
                 return null;
@@ -3127,7 +3133,10 @@ public final class Database {
             while(!cursor.isAfterLast()) {
 
                 boolean dataSuppressed = false;
-                int length = cursor.getInt(3);
+                int length = cursor.getInt(4);
+
+                AttachmentInternal.AttachmentEncoding encoding = AttachmentInternal.AttachmentEncoding.values()[cursor.getInt(3)];
+                int encodedLength = cursor.getInt(5);
 
                 byte[] keyData = cursor.getBlob(1);
                 BlobKey key = new BlobKey(keyData);
@@ -3140,39 +3149,40 @@ public final class Database {
                     }
                     else {
                         byte[] data = attachments.blobForKey(key);
-
                         if(data != null) {
                             dataBase64 = Base64.encodeBytes(data);  // <-- very expensive
                         }
                         else {
                             Log.w(Database.TAG, "Error loading attachment.  Sequence: %s", sequence);
                         }
-
                     }
+                }
 
+                String encodingStr = null;
+                if(encoding!=AttachmentInternal.AttachmentEncoding.AttachmentEncodingNone){
+                    // NOTE: iOS decode if attachment is included int the dict.
+                    encodingStr = "gzip";
                 }
 
                 Map<String, Object> attachment = new HashMap<String, Object>();
-
-
-
                 if(!(dataBase64 != null || dataSuppressed)) {
                     attachment.put("stub", true);
                 }
-
                 if(dataBase64 != null) {
                     attachment.put("data", dataBase64);
                 }
-
                 if (dataSuppressed == true) {
                     attachment.put("follows", true);
                 }
-
                 attachment.put("digest", digestString);
                 String contentType = cursor.getString(2);
                 attachment.put("content_type", contentType);
+                if (encodingStr != null)
+                    attachment.put("encoding", encodingStr);
                 attachment.put("length", length);
-                attachment.put("revpos", cursor.getInt(4));
+                if (encodingStr != null && encodedLength >= 0)
+                    attachment.put("encoded_length", encodedLength);
+                attachment.put("revpos", cursor.getInt(6));
 
                 String filename = cursor.getString(0);
                 result.put(filename, attachment);
@@ -4262,7 +4272,7 @@ public final class Database {
                 // If there's inline attachment data, decode and store it:
                 byte[] newContents;
                 try {
-                    newContents = Base64.decode(newContentBase64);
+                    newContents = Base64.decode(newContentBase64, Base64.DONT_GUNZIP);
                 } catch (IOException e) {
                     throw new CouchbaseLiteException(e, Status.BAD_ENCODING);
                 }

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -612,7 +612,15 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                                 " issue #80): %s", attachment);
                     }
 
-                    FileBody fileBody = new FileBody(file, contentType);
+                    // NOTE: Content-Encoding might not be necessary to set. Apache FileBody does not set Content-Encoding.
+                    //       FileBody always return null for getContentEncoding(), and Content-Encoding header is not set in multipart
+                    // CBL iOS: https://github.com/couchbase/couchbase-lite-ios/blob/feb7ff5eda1e80bd00e5eb19f1d46c793f7a1951/Source/CBL_Pusher.m#L449-L452
+                    String contentEncoding = null;
+                    if(attachment.containsKey("encoding")){
+                        contentEncoding = (String)attachment.get("encoding");
+                    }
+
+                    FileBody fileBody = new CustomFileBody(file, contentType, contentEncoding);
                     multiPart.addPart(attachmentKey, fileBody);
                 }
 
@@ -713,5 +721,20 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
         int generation = Database.parseRevIDNumber(ancestorID);
 
         return generation;
+    }
+
+    // CustomFileBody to support contentEncoding. FileBody returns always null for getContentEncoding()
+    private static class CustomFileBody extends FileBody {
+        private String contentEncoding = null;
+
+        public CustomFileBody(final File file, final String mimeType, final String contentEncoding) {
+            super(file, mimeType);
+            this.contentEncoding = contentEncoding;
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return contentEncoding;
+        }
     }
 }


### PR DESCRIPTION
- Fixed `Attachment.getContent()`. It causes recursive calls that does unzip twice.
- Fixed attachments table access. Previous codes does not handle properly `encoding` and `encoding_length` columns.
- Fixed storing Basic64 encoded gzipped attachment. It was unzipped before storing attachment.
- Fixed push replication to set `Content-Encoding` for gzipped attachment 