### PR TITLE
Encoding of doc ids in replication

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -16,6 +16,7 @@ import com.couchbase.lite.support.RemoteRequestCompletionBlock;
 import com.couchbase.lite.support.SequenceMap;
 import com.couchbase.lite.util.CollectionUtils;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.URIUtils;
 import com.couchbase.lite.util.Utils;
 
 import org.apache.http.HttpResponse;
@@ -23,7 +24,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpResponseException;
 
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -591,7 +591,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         // Construct a query. We want the revision history, and the bodies of attachments that have
         // been added since the latest revisions we have locally.
         // See: http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document
-        StringBuilder path = new StringBuilder("/" + URLEncoder.encode(rev.getDocId()) + "?rev=" + URLEncoder.encode(rev.getRevId()) + "&revs=true&attachments=true");
+        StringBuilder path = new StringBuilder("/");
+        path.append(encodeDocumentId(rev.getDocId()));
+        path.append("?rev=").append(URIUtils.encode(rev.getRevId()));
+        path.append("&revs=true&attachments=true");
 
         // If the document has attachments, add an 'atts_since' param with a list of
         // already-known revisions, so the server can skip sending the bodies of any
@@ -645,9 +648,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         try {
             json = Manager.getObjectMapper().writeValueAsBytes(strings);
         } catch (Exception e) {
-            Log.w(Log.TAG_SYNC, "Unable to serialize json", e);
+            throw new IllegalStateException("Unable to serialize json", e);
         }
-        return URLEncoder.encode(new String(json));
+        return URIUtils.encode(new String(json));
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -632,7 +632,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
             return false;
         }
 
-        final String path = String.format("/%s?new_edits=false", revision.getDocId());
+        final String path = String.format("/%s?new_edits=false", URIUtils.encode(revision.getDocId()));
 
         Log.d(Log.TAG_SYNC, "Uploading multipart request.  Revision: %s", revision);
 

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -602,14 +602,12 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 File file = new File(path);
                 if (!file.exists()) {
                     Log.w(Log.TAG_SYNC, "Unable to find blob file for blobKey: %s - Skipping upload of multipart revision.", blobKey);
-                    multiPart = null;
-                }
-                else {
+                    return false;
+                } else {
                     String contentType = null;
                     if (attachment.containsKey("content_type")) {
                         contentType = (String) attachment.get("content_type");
-                    }
-                    else if (attachment.containsKey("content-type")) {
+                    } else if (attachment.containsKey("content-type")) {
                         Log.w(Log.TAG_SYNC, "Found attachment that uses content-type" +
                                 " field name instead of content_type (see couchbase-lite-android" +
                                 " issue #80): %s", attachment);
@@ -623,7 +621,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                         contentEncoding = (String)attachment.get("encoding");
                     }
 
-                    FileBody fileBody = new CustomFileBody(file, contentType, contentEncoding);
+                    FileBody fileBody = new CustomFileBody(file, attachmentKey, contentType, contentEncoding);
                     multiPart.addPart(attachmentKey, fileBody);
                 }
 
@@ -730,8 +728,8 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
     private static class CustomFileBody extends FileBody {
         private String contentEncoding = null;
 
-        public CustomFileBody(final File file, final String mimeType, final String contentEncoding) {
-            super(file, mimeType);
+        public CustomFileBody(File file, String filename, String mimeType, String contentEncoding) {
+            super(file, filename, mimeType, null);
             this.contentEncoding = contentEncoding;
         }
 

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -632,7 +632,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
             return false;
         }
 
-        final String path = String.format("/%s?new_edits=false", URIUtils.encode(revision.getDocId()));
+        final String path = String.format("/%s?new_edits=false", encodeDocumentId(revision.getDocId()));
 
         Log.d(Log.TAG_SYNC, "Uploading multipart request.  Revision: %s", revision);
 
@@ -681,7 +681,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
             return;
         }
 
-        final String path = String.format("/%s?new_edits=false", URIUtils.encode(rev.getDocId()));
+        final String path = String.format("/%s?new_edits=false", encodeDocumentId(rev.getDocId()));
         Future future = sendAsyncRequest("PUT",
                 path,
                 rev.getProperties(),
@@ -697,9 +697,6 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 });
         pendingFutures.add(future);
     }
-
-
-
 
     // Given a revision and an array of revIDs, finds the latest common ancestor revID
     // and returns its generation #. If there is none, returns 0.

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -18,6 +18,7 @@ import com.couchbase.lite.support.RemoteRequestRetry;
 import com.couchbase.lite.util.CollectionUtils;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.TextUtils;
+import com.couchbase.lite.util.URIUtils;
 import com.couchbase.lite.util.Utils;
 import com.couchbase.org.apache.http.entity.mime.MultipartEntity;
 import com.github.oxo42.stateless4j.StateMachine;
@@ -1609,6 +1610,21 @@ abstract class ReplicationInternal implements BlockingQueueListener{
                     }).start();
                 }
             }
+        }
+    }
+
+    /**
+     * Encodes the given document id for use in an URI.
+     * <p>
+     * Avoids encoding the slash in _design documents since it may cause a 301 redirect.
+     */
+    /* package */ String encodeDocumentId(String docId) {
+        if (docId.startsWith("_design/")) {
+            // http://docs.couchdb.org/en/1.6.1/http-api.html#cap-/{db}/_design/{ddoc}
+            String designDocId = docId.substring("_design/".length());
+            return "_design/".concat(URIUtils.encode(designDocId));
+        } else {
+            return URIUtils.encode(docId);
         }
     }
 }


### PR DESCRIPTION
This is PR #622 rebased:
- Encode document id in uploadMultipartRevision
- Avoid encoding the slash of design documents
- Fix attachment filenames in multipart uploads

Closes #600, #615