### PR TITLE
Fixed Android 597 - problems with pull request

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -594,8 +594,10 @@ public class ChangeTracker implements Runnable {
     public void setPaused(boolean paused) {
         Log.v(Log.TAG, "setPaused: " + paused);
         synchronized (pausedObj) {
-            this.paused = paused;
-            pausedObj.notifyAll();
+            if(this.paused != paused) {
+                this.paused = paused;
+                pausedObj.notifyAll();
+            }
         }
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -11,6 +11,7 @@ import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.storage.SQLException;
 import com.couchbase.lite.support.BatchProcessor;
 import com.couchbase.lite.support.Batcher;
+import com.couchbase.lite.support.CustomFuture;
 import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.support.RemoteRequestCompletionBlock;
 import com.couchbase.lite.support.SequenceMap;
@@ -609,7 +610,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         //create a final version of this variable for the log statement inside
         //FIXME find a way to avoid this
         final String pathInside = path.toString();
-        Future future = sendAsyncMultipartDownloaderRequest("GET", pathInside, null, db, new RemoteRequestCompletionBlock() {
+        CustomFuture future = sendAsyncMultipartDownloaderRequest("GET", pathInside, null, db, new RemoteRequestCompletionBlock() {
 
             @Override
             public void onCompletion(HttpResponse httpResponse, Object result, Throwable e) {
@@ -632,10 +633,12 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
                 // Note that we've finished this task:
                 --httpConnectionCount;
+
                 // Start another task if there are still revisions waiting to be pulled:
                 pullRemoteRevisions();
             }
         });
+        future.setQueue(pendingFutures);
         pendingFutures.add(future);
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -693,7 +693,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             processChangeTrackerChange(change);
         } catch (Exception e) {
             Log.e(Log.TAG_SYNC, "Error processChangeTrackerChange(): %s", e);
-            e.printStackTrace();
             throw new RuntimeException(e);
         }
     }
@@ -1009,7 +1008,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     protected void pauseOrResume(){
         int pending = batcher.count() + pendingSequences.count();
-        //Log.e(Log.TAG_SYNC, "[pauseOrResume()] batcher.count()="+batcher.count() + ", pendingSequences.count()="+pendingSequences.count()+", pendingFutures.size()=" +pendingFutures.size());
         changeTracker.setPaused(pending >= MAX_PENDING_DOCS);
     }
 }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -620,11 +620,11 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     Map<String, Object> properties = (Map<String, Object>) result;
                     PulledRevision gotRev = new PulledRevision(properties);
                     gotRev.setSequence(rev.getSequence());
-
-                    //if(gotRev.getBody() != null)
-                    //    gotRev.getBody().compact();
-
+                    
                     Log.d(Log.TAG_SYNC, "%s: pullRemoteRevision add rev: %s to batcher: %s", PullerInternal.this, gotRev, downloadsToInsert);
+
+                    if(gotRev.getBody() != null)
+                        gotRev.getBody().compact();
 
                     // Add to batcher ... eventually it will be fed to -insertRevisions:.
                     downloadsToInsert.queueObject(gotRev);

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -11,6 +11,7 @@ import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.support.BatchProcessor;
 import com.couchbase.lite.support.Batcher;
 import com.couchbase.lite.support.BlockingQueueListener;
+import com.couchbase.lite.support.CustomFuture;
 import com.couchbase.lite.support.CustomLinkedBlockingQueue;
 import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.support.RemoteRequestCompletionBlock;
@@ -596,7 +597,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
      * @exclude
      */
     @InterfaceAudience.Private
-    public Future sendAsyncMultipartDownloaderRequest(String method, String relativePath, Object body, Database db, RemoteRequestCompletionBlock onCompletion) {
+    public CustomFuture sendAsyncMultipartDownloaderRequest(String method, String relativePath, Object body, Database db, RemoteRequestCompletionBlock onCompletion) {
         try {
 
             String urlStr = buildRelativeURLString(relativePath);
@@ -617,7 +618,7 @@ abstract class ReplicationInternal implements BlockingQueueListener{
 
             request.setAuthenticator(getAuthenticator());
 
-            Future future = request.submit();
+            CustomFuture future = request.submit();
             return future;
         } catch (MalformedURLException e) {
             Log.e(Log.TAG_SYNC, "Malformed URL for async request", e);

--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -107,28 +108,25 @@ public class Batcher<T> {
     }
 
     public void waitForPendingFutures() {
-
         Log.d(Log.TAG_BATCHER, "%s: waitForPendingFutures", this);
-
         try {
-
             while (!pendingFutures.isEmpty()) {
                 Future future = pendingFutures.take();
                 try {
                     Log.d(Log.TAG_BATCHER, "calling future.get() on %s", future);
                     future.get();
                     Log.d(Log.TAG_BATCHER, "done calling future.get() on %s", future);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+                } catch (CancellationException e) {
+                    Log.i(Log.TAG_BATCHER, "Task was canceled: " + e.getMessage());
                 } catch (ExecutionException e) {
-                    e.printStackTrace();
+                    Log.e(Log.TAG_BATCHER, "ERROR: Task aborted: " + e.getMessage());
+                } catch (InterruptedException e) {
+                    Log.w(Log.TAG_BATCHER, e.getMessage());
                 }
             }
-
         } catch (Exception e) {
             Log.e(Log.TAG_BATCHER, "Exception waiting for pending futures: %s", e);
         }
-
         Log.d(Log.TAG_BATCHER, "%s: /waitForPendingFutures", this);
     }
 

--- a/src/main/java/com/couchbase/lite/support/CustomFuture.java
+++ b/src/main/java/com/couchbase/lite/support/CustomFuture.java
@@ -1,0 +1,11 @@
+package com.couchbase.lite.support;
+
+import java.util.Queue;
+import java.util.concurrent.Future;
+
+/**
+ * Created by hideki on 5/21/15.
+ */
+public interface CustomFuture<V> extends Future<V> {
+    void setQueue(Queue queue);
+}

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -12,6 +12,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -31,7 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * in between the retries.
  *
  */
-public class RemoteRequestRetry<T> implements Future<T> {
+public class RemoteRequestRetry<T> implements CustomFuture<T> {
 
     public static int MAX_RETRIES = 3;  // total number of attempts = 4 (1 initial + MAX_RETRIES)
     public static int RETRY_DELAY_MS = 4 * 1000; // 4 sec
@@ -64,8 +65,17 @@ public class RemoteRequestRetry<T> implements Future<T> {
 
     private RemoteRequestType requestType;
 
+
     // for Retry task
     ScheduledFuture retryFuture = null;
+
+    private Queue queue = null;
+
+    @Override
+    public void setQueue(Queue queue) {
+        this.queue = queue;
+    }
+
 
     /**
      * The kind of RemoteRequest that will be created on each retry attempt
@@ -105,14 +115,14 @@ public class RemoteRequestRetry<T> implements Future<T> {
 
     }
 
-    public Future submit() {
+    public CustomFuture submit() {
         return submit(false);
     }
 
     /**
      * @param gzip true - send gzipped request
      */
-    public Future submit(boolean gzip) {
+    public CustomFuture submit(boolean gzip) {
 
         RemoteRequest request = generateRemoteRequest();
 
@@ -185,6 +195,13 @@ public class RemoteRequestRetry<T> implements Future<T> {
         return request;
     }
 
+    void removeFromQueue() {
+        if (queue != null) {
+            queue.remove(this);
+            setQueue(null);
+        }
+    }
+
     RemoteRequestCompletionBlock onCompletionInner = new RemoteRequestCompletionBlock() {
 
         private void completed(HttpResponse httpResponse, Object result, Throwable e) {
@@ -194,11 +211,13 @@ public class RemoteRequestRetry<T> implements Future<T> {
             completedSuccessfully.set(true);
 
             onCompletionCaller.onCompletion(requestHttpResponse, requestResult, requestThrowable);
-
+            
             // release unnecessary references to reduce memory usage as soon as called onComplete().
             requestHttpResponse = null;
             requestResult = null;
             requestThrowable = null;
+
+            removeFromQueue();
         }
 
         @Override

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -185,7 +185,6 @@ public class RemoteRequestRetry<T> implements Future<T> {
         return request;
     }
 
-
     RemoteRequestCompletionBlock onCompletionInner = new RemoteRequestCompletionBlock() {
 
         private void completed(HttpResponse httpResponse, Object result, Throwable e) {
@@ -193,7 +192,13 @@ public class RemoteRequestRetry<T> implements Future<T> {
             requestResult = result;
             requestThrowable = e;
             completedSuccessfully.set(true);
+
             onCompletionCaller.onCompletion(requestHttpResponse, requestResult, requestThrowable);
+
+            // release unnecessary references to reduce memory usage as soon as called onComplete().
+            requestHttpResponse = null;
+            requestResult = null;
+            requestThrowable = null;
         }
 
         @Override


### PR DESCRIPTION
- To reduce peak memory usage, Call `RevisionInternal.Body.comact()` to release document object
- `setPaused()` will notify a change only when `paused` value changes.
- `ChangeTracker` directly post change into batcher with its thread, in stead of using workExecutor (pull replicator) thread.
- Release unnecessary references to reduce memory usage as soon as called onComplete()
- By extending Future, Future is allowed to remove itself from pendingFutures queue.
- Fixed Out-Of-Index issue that is caused by multi-threading