### PR TITLE
Fixed #643 - Add conflict check in `PullerInternal.processChangeTrack…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
+++ b/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
@@ -12,6 +12,9 @@ import java.util.Map;
 @InterfaceAudience.Private
 class PulledRevision extends RevisionInternal {
 
+    protected String remoteSequenceID = null;
+    protected boolean conflicted = false;
+
     public PulledRevision(Body body) {
         super(body);
     }
@@ -24,8 +27,6 @@ class PulledRevision extends RevisionInternal {
         super(properties);
     }
 
-    protected String remoteSequenceID;
-
     public String getRemoteSequenceID() {
         return remoteSequenceID;
     }
@@ -34,4 +35,11 @@ class PulledRevision extends RevisionInternal {
         this.remoteSequenceID = remoteSequenceID;
     }
 
+    public boolean isConflicted() {
+        return conflicted;
+    }
+
+    public void setConflicted(boolean conflicted) {
+        this.conflicted = conflicted;
+    }
 }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -191,19 +191,14 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         Log.v(Log.TAG_SYNC, "%s: fetching %s remote revisions...", this, inboxCount);
 
         // Dump the revs into the queue of revs to pull from the remote db:
-
         for (int i = 0; i < inbox.size(); i++) {
-
             PulledRevision rev = (PulledRevision) inbox.get(i);
-
-            //TODO: add support for rev isConflicted
-            if (canBulkGet || (rev.getGeneration() == 1 && !rev.isDeleted())) { // &&!rev.isConflicted)
+            if (canBulkGet || (rev.getGeneration() == 1 && !rev.isDeleted() && !rev.isConflicted())) {
                 bulkRevsToPull.add(rev);
             }
             else {
                 queueRemoteRevision(rev);
             }
-
             rev.setSequence(pendingSequences.addValue(rev.getRemoteSequenceID()));
         }
         pullRemoteRevisions();
@@ -723,12 +718,15 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             if (revID == null) {
                 continue;
             }
+
             PulledRevision rev = new PulledRevision(docID, revID, deleted);
+
+            // Remember its remote sequence ID (opaque), and make up a numeric sequence
+            // based on the order in which it appeared in the _changes feed:
             rev.setRemoteSequenceID(lastSequence);
 
-            // TODO: Need to do conflict check?
-            // if (revIDs.count > 1)
-            //    rev.conflicted = true;
+            if(changes.size() > 1)
+                rev.setConflicted(true);
 
             Log.d(Log.TAG_SYNC, "%s: adding rev to inbox %s", this, rev);
 


### PR DESCRIPTION
…erChange()`

For Java version, conflict check was not implemented in ChangeTracker. This is just port it from iOS version.

iOS codes
https://github.com/couchbase/couchbase-lite-ios/blob/4cc63fde38bb213f251380da1cc7c58e75d0e0ba/Source/CBL_Puller.m#L241-L242
https://github.com/couchbase/couchbase-lite-ios/blob/4cc63fde38bb213f251380da1cc7c58e75d0e0ba/Source/CBL_Puller.m#L330