### PR TITLE
Needed for the ability to mock the database, for test purposes

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -68,7 +68,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * A CouchbaseLite database.
  */
-public final class Database {
+public class Database {
 
     // Default value for maxRevTreeDepth, the max rev depth to preserve in a prune operation
     private static final int DEFAULT_MAX_REVS = Integer.MAX_VALUE;


### PR DESCRIPTION
We need this ability for unit testing in Android Studio.

We were hoping to be able to create actual databases only using the JVM, but got UnsupportedOperationException when attempting to create a Manager() without parameters (e.g. the Android independant version).

Simply mocking the databases is our next best step for now, in light of a non-Android implementation of databases not yet being available.