### PR TITLE
Fixed #713 - BatcherTest failure

### DIFF
--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -53,6 +53,7 @@ public class Batcher<T> {
         this.processor = processor;
         this.inbox = Collections.synchronizedList(new ArrayList<T>());
         this.scheduled = false;
+        this.lastProcessedTime = System.currentTimeMillis();
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- At first time to call addObject(), lastProcessedTime is 0. So Batcher process immediatly. For testing purpose, set current time in constructor.