### PR TITLE
Integrate with couchbase-lite-java-sqlcipher

### DIFF
--- a/src/main/java/com/couchbase/lite/DatabaseUpgrade.java
+++ b/src/main/java/com/couchbase/lite/DatabaseUpgrade.java
@@ -76,9 +76,8 @@ final public class DatabaseUpgrade {
                 return false;
             }
 
-            // Open source (SQLite) database:
             // TODO: We also need encryption key for database upgrade.
-            if (!storageEngine.open(path, null)) {
+            if (!storageEngine.open(path)) {
                 Log.e(TAG, "Upgrade failed: Couldn't open new db: %s", path);
                 return false;
             }

--- a/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngine.java
@@ -21,7 +21,7 @@ public interface SQLiteStorageEngine {
     int CONFLICT_IGNORE = 4;
     int CONFLICT_REPLACE = 5;
 
-    boolean open(String path, String encryptionKey) throws SQLException;
+    boolean open(String path) throws SQLException;
 
     int getVersion();
 

--- a/src/main/java/com/couchbase/lite/support/security/SymmetricKey.java
+++ b/src/main/java/com/couchbase/lite/support/security/SymmetricKey.java
@@ -125,7 +125,7 @@ public class SymmetricKey {
      * @return hex string of the key data
      */
     public String getHexData() {
-        return Utils.bytesToHex(keyData);
+        return Utils.bytesToHex(keyData).toUpperCase();
     }
 
     /**


### PR DESCRIPTION
- Reverted SQLiteStorageEngine.open() method so there is no encryption key parameter anymore.
- Implemented decrypt() method in SQLiteStore.open() to setup the database key and try to decrypt. This is inline with the iOS implementation.
- [Enhanced] Closed cursor object immediately after finish using it in SQLiteStore.pruneRevsToMaxDepth(). This allows to return the connection hold by the cursor to the connection pool sooner.
- [Enhanced] Closed cursor object immediately after finish using it in SQLiteViewStore.setVersion(). This allows to return the connection hold by the cursor to the connection pool sooner.
- Make hex string representation of the SymmetricKey upppercase inlined with iOS.

Reference: couchbase/couchbase-lite-java#68