### PR TITLE
Fixed #717 - testContinuousPushReplicationGoesIdleTooSoon causes nati…

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1194,7 +1194,9 @@ public class Database implements StoreDelegate {
 
     @InterfaceAudience.Private
     public RevisionInternal loadRevisionBody(RevisionInternal rev) throws CouchbaseLiteException {
-        return store.loadRevisionBody(rev);
+        synchronized(store) {
+            return store.loadRevisionBody(rev);
+        }
     }
 
     /**
@@ -1759,7 +1761,9 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Private
     public List<RevisionInternal> getRevisionHistory(RevisionInternal rev) {
-        return store.getRevisionHistory(rev);
+        synchronized(store) {
+            return store.getRevisionHistory(rev);
+        }
     }
 
     private String getDesignDocFunction(String fnName, String key, List<String> outLanguageList) {

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1194,6 +1194,10 @@ public class Database implements StoreDelegate {
 
     @InterfaceAudience.Private
     public RevisionInternal loadRevisionBody(RevisionInternal rev) throws CouchbaseLiteException {
+        // loadRevisionBody() and getRevisionHistory() are called back by RemoteRequest threads.
+        // That causes non-synchronized access to database.
+        // This issue might not be occured with SQLite because SQLiteDatabase from Android takes
+        // care multi-threads access.
         synchronized(store) {
             return store.loadRevisionBody(rev);
         }
@@ -1761,6 +1765,10 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Private
     public List<RevisionInternal> getRevisionHistory(RevisionInternal rev) {
+        // loadRevisionBody() and getRevisionHistory() are called back by RemoteRequest threads.
+        // That causes non-synchronized access to database.
+        // This issue might not be occured with SQLite because SQLiteDatabase from Android takes
+        // care multi-threads access.
         synchronized(store) {
             return store.getRevisionHistory(rev);
         }


### PR DESCRIPTION
…ve crash if unit test run from command line on OSX

- Native crash issue was addressed by couchbaselabs/couchbase-lite-java-forestdb/pull/5
- However, root cause of this issue still caused the test failure.
- Some of database access is from different threads. For example, threads run RemoteRequest. Callback codes from RemoteRequest access database.
- To make callback codes access database synchronously, add synchronized block for some database accessing codes.
- Currently I knows this two methods caused invalid database access, maybe more methods should be synchronized.