### PR TITLE
Revised exception caching and throwing in SQLiteStore.decrypt() method

### DIFF
--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -334,14 +334,15 @@ public class SQLiteStore implements Store {
                 throw new CouchbaseLiteException("Cannot decrypt or access the database",
                         Status.DB_ERROR);
             }
-        } catch (SQLException e) {
+        } catch (Exception e) {
             Log.w(TAG, "SQLiteStore: database is unreadable", e);
             if (e.getMessage() != null &&
                 e.getMessage().contains("file is encrypted or is not a database (code 26)")) {
                 throw new CouchbaseLiteException("Cannot decrypt or access the database",
                         Status.UNAUTHORIZED);
+            } else {
+                throw new CouchbaseLiteException(e, Status.DB_ERROR);
             }
-            throw  e;
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
Per StorageEngine interface, the rawQuery() method doesn't expect to throw SQLException. Change from caching SQLException to Exception to cache any runtime exception that could be thrown.