### PR TITLE
Fixed #664 - Creating authenticator with empty password throws ArrayI…

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -267,10 +267,11 @@ public class RemoteRequest implements Runnable {
         if (userInfo != null) {
             if (userInfo.contains(":") && !userInfo.trim().equals(":")) {
                 String[] userInfoElements = userInfo.split(":");
-                String username = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[0]): userInfoElements[0];
-                String password = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[1]): userInfoElements[1];
+                String username = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[0]) : userInfoElements[0];
+                String password = "";
+                if(userInfoElements.length >= 2)
+                    password = isUrlBasedUserInfo ? URIUtils.decode(userInfoElements[1]) : userInfoElements[1];
                 final Credentials credentials = new UsernamePasswordCredentials(username, password);
-
                 if (httpClient instanceof DefaultHttpClient) {
                     DefaultHttpClient dhc = (DefaultHttpClient) httpClient;
                     HttpRequestInterceptor preemptiveAuth = new HttpRequestInterceptor() {


### PR DESCRIPTION
…ndexOutOfBoundsException

In case userInfo is `username:`, userInfoElements is `['username']`. So just added line to check size of userInfoElements array.