### PR TITLE
Fixed #719 #720 Support SQLite database and attachment rekey

### DIFF
--- a/src/main/java/com/couchbase/lite/BlobStore.java
+++ b/src/main/java/com/couchbase/lite/BlobStore.java
@@ -206,7 +206,7 @@ public class BlobStore {
         // action, because farther down we create an action to move it...
         File tempDir = new File (context.getTempDir(), Misc.CreateUUID());
         final File tempStoreDir = tempDir.mkdirs() ? tempDir : null;
-        // Mark delete on exit:
+        // Mark delete on exit (optional and work on Java only):
         if (tempStoreDir != null)
             tempStoreDir.deleteOnExit();
 
@@ -264,7 +264,7 @@ public class BlobStore {
                             writer.cancel();
                         throw new ActionException(e);
                     } finally {
-                        // Mark delete on exit to the temporary blob file:
+                        // Mark delete on exit (optional and work on Java only):
                         if (writer != null)
                             new File(tempStore.getRawPathForKey(writer.getBlobKey())).deleteOnExit();
                         // Close readStream:

--- a/src/main/java/com/couchbase/lite/Context.java
+++ b/src/main/java/com/couchbase/lite/Context.java
@@ -19,14 +19,19 @@ public interface Context {
     /**
      * The files dir.  On Android implementation, simply proxies call to underlying Context
      */
-    public File getFilesDir();
+    File getFilesDir();
+
+    /**
+     * Get temporary directory. The temporary directory will be used to store temporary files.
+     */
+    File getTempDir();
 
     /**
      * Override the default behavior and set your own NetworkReachabilityManager subclass,
      * which allows you to completely control how to respond to network reachability changes
      * in your app affects the replicators that are listening for change events.
      */
-    public void setNetworkReachabilityManager(NetworkReachabilityManager networkReachabilityManager);
+    void setNetworkReachabilityManager(NetworkReachabilityManager networkReachabilityManager);
 
     /**
      * Replicators call this to get the NetworkReachabilityManager, and they register/unregister
@@ -35,13 +40,13 @@ public interface Context {
      * If setNetworkReachabilityManager() was called prior to this, that instance will be used.
      * Otherwise, the context will create a new default reachability manager and return that.
      */
-    public NetworkReachabilityManager getNetworkReachabilityManager();
+    NetworkReachabilityManager getNetworkReachabilityManager();
 
 
     /**
      * Get the SQLiteStorageEngineFactory, or null if none has been set, in which case
      * the default will be used.
      */
-    public SQLiteStorageEngineFactory getSQLiteStorageEngineFactory();
+    SQLiteStorageEngineFactory getSQLiteStorageEngineFactory();
 
 }

--- a/src/main/java/com/couchbase/lite/store/EncryptableStore.java
+++ b/src/main/java/com/couchbase/lite/store/EncryptableStore.java
@@ -1,0 +1,26 @@
+/**
+ * Created by Pasin Suriyentrakorn on 8/29/15.
+ * <p/>
+ * Copyright (c) 2015 Couchbase, Inc All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.couchbase.lite.store;
+
+import com.couchbase.lite.support.action.Action;
+import com.couchbase.lite.support.security.SymmetricKey;
+
+public interface EncryptableStore {
+    void setEncryptionKey(SymmetricKey key);
+
+    Action actionToChangeEncryptionKey(SymmetricKey newKey);
+}

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -29,6 +29,9 @@ import com.couchbase.lite.storage.SQLException;
 import com.couchbase.lite.storage.SQLiteStorageEngine;
 import com.couchbase.lite.storage.SQLiteStorageEngineFactory;
 import com.couchbase.lite.support.RevisionUtils;
+import com.couchbase.lite.support.action.Action;
+import com.couchbase.lite.support.action.ActionBlock;
+import com.couchbase.lite.support.action.ActionException;
 import com.couchbase.lite.support.security.SymmetricKey;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.SQLiteUtils;
@@ -46,7 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class SQLiteStore implements Store {
+public class SQLiteStore implements Store, EncryptableStore {
     public String TAG = Log.TAG_DATABASE;
 
     public static String kDBFilename = "db.sqlite3";
@@ -117,6 +120,7 @@ public class SQLiteStore implements Store {
     private TransactionLevel transactionLevel;
     private StoreDelegate delegate;
     private int maxRevTreeDepth;
+    private SymmetricKey encryptionKey;
 
     ///////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -169,7 +173,6 @@ public class SQLiteStore implements Store {
             // Open database:
             storageEngine.open(path);
             // Try to decrypt or access the database:
-            SymmetricKey encryptionKey = delegate.getEncryptionKey();
             decrypt(encryptionKey);
             isOpenSuccess = true;
         } catch (SQLException e) {
@@ -348,6 +351,125 @@ public class SQLiteStore implements Store {
                 cursor.close();
             }
         }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // ENCRYPTABLE STORE
+    ///////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void setEncryptionKey(SymmetricKey key) {
+        encryptionKey = key;
+    }
+
+    @Override
+    public Action actionToChangeEncryptionKey(final SymmetricKey newKey) {
+        if (!storageEngine.supportEncryption())
+            return null;
+
+        Action action = new Action();
+        final AtomicBoolean dbWasClosed = new AtomicBoolean(false);
+
+        // Make a path for a tempoary database file:
+        final File tempDbFile = new File(manager.getDirectory(), Misc.CreateUUID());
+        action.add(null, new ActionBlock() {
+            @Override
+            public void execute() throws ActionException {
+                if (tempDbFile.exists()) {
+                    if (!tempDbFile.delete()) {
+                        throw new ActionException("Cannot delete the temp database file " +
+                                tempDbFile.getAbsolutePath());
+                    }
+                }
+            }
+        }, null);
+
+        // Create & attach the temporary database encrypted with the new key:
+        action.add(
+            // Perform:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    String keyStr = newKey != null ? newKey.getHexData() : "";
+                    String sql = "ATTACH DATABASE ? AS rekeyed_db KEY \"x'" + keyStr + "'\"";
+                    String[] args = {tempDbFile.getAbsolutePath()};
+                    try {
+                        storageEngine.execSQL(sql, args);
+                    } catch (Exception e) {
+                        throw new ActionException(e);
+                    }
+                }
+            },
+            // Backout or cleanup:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    if (dbWasClosed.get())
+                        return;
+                    try {
+                        storageEngine.execSQL("DETACH DATABASE rekeyed_db");
+                    } catch (Exception e) {
+                        throw new ActionException(e);
+                    }
+                }
+            });
+
+        // Export the current database's contents to the new one:
+        action.add(new ActionBlock() {
+            @Override
+            public void execute() throws ActionException {
+                try {
+                    storageEngine.execSQL("SELECT sqlcipher_export('rekeyed_db')");
+                    storageEngine.execSQL("PRAGMA rekeyed_db.user_version = " +
+                            storageEngine.getVersion());
+                } catch (Exception e) {
+                    throw new ActionException(e);
+                }
+            }
+        }, null, null);
+
+        // Close the database (and re-open it on cleanup):
+        action.add(
+            // Perform:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    storageEngine.close();
+                    dbWasClosed.set(true);
+                }
+            },
+            // Backout:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    try {
+                        if (!open())
+                            throw new ActionException("Cannot open the SQLiteStore");
+                    } catch (CouchbaseLiteException e) {
+                        throw new ActionException(e);
+                    }
+                }
+            },
+            // Cleanup:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    setEncryptionKey(newKey);
+                    try {
+                        if (!open())
+                            throw new ActionException("Cannot open the SQLiteStore");
+                    } catch (CouchbaseLiteException e) {
+                        throw new ActionException(e);
+                    }
+                }
+            }
+        );
+
+        // Overwrite the old db file with the new one:
+        action.add(Action.moveAndReplaceFile(tempDbFile.getAbsolutePath(), path,
+                manager.getContext().getTempDir().getAbsolutePath()));
+
+        return action;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/couchbase/lite/store/StoreDelegate.java
+++ b/src/main/java/com/couchbase/lite/store/StoreDelegate.java
@@ -18,12 +18,6 @@ import java.util.Map;
  */
 public interface StoreDelegate {
     /**
-     * Get encryption key registered with this database.
-     * @return encryption key
-     */
-    public SymmetricKey getEncryptionKey();
-
-    /**
      * Called whenever the outermost transaction completes.
      *
      * @param committed YES on commit, NO if the transaction was aborted.

--- a/src/main/java/com/couchbase/lite/support/action/Action.java
+++ b/src/main/java/com/couchbase/lite/support/action/Action.java
@@ -1,0 +1,342 @@
+/**
+ * Created by Pasin Suriyentrakorn on 8/29/15.
+ * <p/>
+ * Copyright (c) 2015 Couchbase, Inc All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.couchbase.lite.support.action;
+
+import com.couchbase.lite.Misc;
+import com.couchbase.lite.support.FileDirUtils;
+import com.couchbase.lite.util.Log;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An AtomicAction implementation to provide an ability to perform actions,
+ * back them out if there is an error, and clean up.
+ */
+public class Action implements AtomicAction {
+    private List<ActionBlock> peforms;
+    private List<ActionBlock> backouts;
+    private List<ActionBlock> cleanUps;
+
+    private int nextStep;
+
+    private Exception lastError;
+    private int failedStep;
+
+    private static ActionBlock nullAction;
+    static {
+        nullAction = new ActionBlock() {
+            @Override
+            public void execute() throws ActionException { }
+        };
+    }
+
+    public Action() {
+        peforms = new ArrayList<ActionBlock>();
+        backouts = new ArrayList<ActionBlock>();
+        cleanUps = new ArrayList<ActionBlock>();
+        nextStep = 0;
+    }
+
+    public Action(ActionBlock perform, ActionBlock backout, ActionBlock cleanup) {
+        this();
+        add(perform, backout, cleanup);
+    }
+
+    /**
+     * @return Last exception occurred
+     */
+    public Exception getLastError() {
+        return lastError;
+    }
+
+    /**
+     * @return Last failure step
+     */
+    public int getFailedStep() {
+        return failedStep;
+    }
+
+    /**
+     * Adds an action as a step of thid one.
+     * @param action
+     */
+    public void add(final AtomicAction action) {
+        if (action instanceof Action) {
+            Action a = (Action)action;
+            peforms.addAll(a.peforms);
+            backouts.addAll(a.backouts);
+            cleanUps.addAll(a.cleanUps);
+        } else {
+            add(new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    action.perform();
+                }
+            }, new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    action.backout();
+                }
+            }, new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    action.cleanup();
+                }
+            });
+        }
+    }
+
+    /**
+     * Adds an action as a step of this one. The action has three components, each optional.
+     * @param perform A block that tries to perform the action, or returns an error if it fails.
+     *                (If the block fails, it should clean up; the backOut will _not_ be called!)
+     * @param backout A block that undoes the effect of the action; it will be called if a _later_
+     *                action fails, so that the system can be returned to the initial state.
+     * @param cleanup A block that performs any necessary cleanup after all actions have been
+     *                performed (e.g. deleting a temporary file.)
+     */
+    public void add(ActionBlock perform, ActionBlock backout, ActionBlock cleanup) {
+        peforms.add(perform != null ? perform : nullAction);
+        backouts.add(backout != null ? backout : nullAction);
+        cleanUps.add(cleanup != null ? cleanup : nullAction);
+    }
+
+    /**
+     * Adds an action as a step of this one. The action has two components (backout and cleanup
+     * are the same action), each optional.
+     * @param perform A block that tries to perform the action, or returns an error if it fails.
+     *                (If the block fails, it should clean up; the backOut will _not_ be called!)
+     * @param backoutOrCleanup A block that can be both backout and cleanup block.A backout block.
+     */
+    public void add(ActionBlock perform, ActionBlock backoutOrCleanup) {
+        add(perform, backoutOrCleanup, backoutOrCleanup);
+    }
+
+    /**
+     * Performs all the actions in order.
+     * If any action fails, backs out the previously performed actions in reverse order.
+     * If the actions succeeded, cleans them up in reverse order.
+     * The `lastError` property is set to the exception thrown by the failed perform block.
+     * The `failedStep` property is set to the index of the failed perform block.
+     * @throws ActionException
+     */
+    public void run() throws ActionException {
+        try {
+            perform();
+            try {
+                cleanup(); // Ignore exception
+            } catch (ActionException e) {}
+            lastError = null;
+        } catch (ActionException e) {
+            // (perform: has already backed out whatever it did)
+            lastError = e;
+            throw e;
+        }
+    }
+
+    @Override
+    public void perform() throws ActionException {
+        if (nextStep > 0)
+            throw new IllegalStateException("Actions have already been run");
+
+        failedStep = -1;
+        for (; nextStep < peforms.size(); ++nextStep) {
+            try {
+                doAction(peforms);
+            } catch (ActionException e) {
+                failedStep = nextStep;
+                if (nextStep > 0) {
+                    try {
+                        backout(); // Ignore error
+                    } catch (ActionException backoutEx) {}
+                }
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void backout() throws ActionException {
+        if (nextStep == 0)
+            throw new IllegalStateException("Actions have not been run");
+
+        while(nextStep-- > 0) {
+            try {
+                doAction(backouts);
+            } catch (ActionException e) {
+                Log.e(Log.TAG_ACTION, "Error backing out step: " + nextStep, e);
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public void cleanup() throws ActionException {
+        if (nextStep != peforms.size())
+            throw new IllegalStateException("Actions did not all run");
+
+        while(nextStep-- > 0) {
+            try {
+                doAction(cleanUps);
+            } catch (ActionException e) {
+                Log.e(Log.TAG_ACTION, "Error cleaning up step: " + nextStep, e);
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Subroutine that calls an action block from either performs, backOuts or cleanUps.
+     * @param actions
+     * @throws ActionException
+     */
+    private void doAction(List<ActionBlock> actions) throws ActionException {
+        try {
+            actions.get(nextStep).execute();
+        } catch (ActionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ActionException("Exception raised by step: " + nextStep, e);
+        }
+    }
+
+    /** File-based actions: **/
+
+    /**
+     * Deletes the file/directory at the given path, if it exists.
+     * @param path Path to the file or directory to be deleted
+     * @param tempDir Path to a tem directory used for backing out the deleted file
+     * @return A delete file Action
+     */
+    public static Action deleteFile(final String path, final String tempDir) {
+        if (path == null)
+            throw new IllegalArgumentException("The path variable cannot be null");
+        if (tempDir == null)
+            throw new IllegalArgumentException("The tempDir variable cannot be null");
+
+        final File tempFile = new File(tempDir, Misc.CreateUUID());
+        final AtomicBoolean exists = new AtomicBoolean();
+        return new Action(
+            // Perform:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    File file = new File(path);
+                    if (file.exists()) {
+                        if (tempFile == null)
+                            throw new ActionException("Cannot perform file deletion as " +
+                                    "the temporary file cannot be crated.");
+
+                        boolean success = new File(path).renameTo(tempFile);
+                        exists.set(success);
+                        if (success)
+                            // Mark delete on exit
+                            tempFile.deleteOnExit();
+                        else
+                            throw new ActionException("Cannot move file " + path +
+                                    " to " + tempFile.getAbsolutePath());
+                    }
+                }
+            },
+            // Backout:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    if (exists.get()) {
+                        if (!tempFile.renameTo(new File(path)))
+                            throw new ActionException("Cannot move file " +
+                                    tempFile.getAbsolutePath() + " to " + path);
+                    }
+                }
+            },
+            // Cleanup:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    if (exists.get()) {
+                        if (tempFile.isDirectory()) {
+                            if (!FileDirUtils.deleteRecursive(tempFile))
+                                throw new ActionException("Cannot delete the temporary directory " +
+                                        tempFile.getAbsolutePath());
+                        } else {
+                            if (!tempFile.delete())
+                                throw new ActionException("Cannot delete the temporary file " +
+                                        tempFile.getAbsolutePath());
+                        }
+                    }
+                }
+            });
+    }
+
+    /**
+     * Moves the file/directory to a new location, which must not already exist.
+     * @param srcPath Source path
+     * @param destPath Destination path which must not exist
+     * @return A moveFileToEmptyPath action
+     */
+    public static Action moveFileToEmptyPath(final String srcPath, final String destPath) {
+        if (srcPath == null)
+            throw new IllegalArgumentException("The srcPath variable cannot be null");
+        if (destPath == null)
+            throw new IllegalArgumentException("The destPath variable cannot be null");
+
+        return new Action(
+            // Perform:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    File destFile = new File(destPath);
+                    if (destFile.exists())
+                        throw new ActionException("Cannot move file. " +
+                                "The Destination file " + destPath + " already exists.");
+                    boolean success = new File(srcPath).renameTo(destFile);
+                    if (!success)
+                        throw new ActionException("Cannot move file " + srcPath +
+                                " to " + destPath);
+                }
+            },
+            // Backout:
+            new ActionBlock() {
+                @Override
+                public void execute() throws ActionException {
+                    boolean success = new File(destPath).renameTo(new File(srcPath));
+                    if (!success)
+                        throw new ActionException("Cannot move file " + destPath +
+                                " to " + srcPath);
+                }
+            },
+            // Cleanup:
+            null);
+    }
+
+    /**
+     * Moves the file/directory to a new location, replacing anything that already exists there.
+     * @param srcPath Source path
+     * @param destPath Destination path to be replaced
+     * @param tempDir Path to a temp directory used for backing out file deletion
+     * @return A moveAndReplaceFile action
+     */
+    public static Action moveAndReplaceFile(String srcPath, String destPath, String tempDir) {
+        Action seq = new Action();
+        seq.add(deleteFile(destPath, tempDir));
+        seq.add(moveFileToEmptyPath(srcPath, destPath));
+        return seq;
+    }
+}

--- a/src/main/java/com/couchbase/lite/support/action/Action.java
+++ b/src/main/java/com/couchbase/lite/support/action/Action.java
@@ -247,7 +247,7 @@ public class Action implements AtomicAction {
                         boolean success = new File(path).renameTo(tempFile);
                         exists.set(success);
                         if (success)
-                            // Mark delete on exit
+                            // Mark delete on exit (optional and work on Java only):
                             tempFile.deleteOnExit();
                         else
                             throw new ActionException("Cannot move file " + path +

--- a/src/main/java/com/couchbase/lite/support/action/ActionBlock.java
+++ b/src/main/java/com/couchbase/lite/support/action/ActionBlock.java
@@ -1,0 +1,27 @@
+/**
+ * Created by Pasin Suriyentrakorn on 8/29/15.
+ * <p/>
+ * Copyright (c) 2015 Couchbase, Inc All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.couchbase.lite.support.action;
+
+/**
+ * An action block interface.
+ */
+public interface ActionBlock {
+    /**
+     * Execute the action.
+     * @throws ActionException
+     */
+    void execute() throws ActionException;
+}

--- a/src/main/java/com/couchbase/lite/support/action/ActionException.java
+++ b/src/main/java/com/couchbase/lite/support/action/ActionException.java
@@ -1,0 +1,35 @@
+/**
+ * Created by Pasin Suriyentrakorn on 8/29/15.
+ * <p/>
+ * Copyright (c) 2015 Couchbase, Inc All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.couchbase.lite.support.action;
+
+public class ActionException extends Exception {
+    public ActionException() {
+        super();
+    }
+
+    public ActionException(String error) {
+        super(error);
+    }
+
+    public ActionException(String error, Throwable cause) {
+        super(error, cause);
+    }
+
+    public ActionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/couchbase/lite/support/action/AtomicAction.java
+++ b/src/main/java/com/couchbase/lite/support/action/AtomicAction.java
@@ -1,0 +1,42 @@
+/**
+ * Created by Pasin Suriyentrakorn on 8/29/15.
+ * <p/>
+ * Copyright (c) 2015 Couchbase, Inc All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.couchbase.lite.support.action;
+
+/**
+ * An abstraction whose instances can perform some action and back it out.
+ */
+public interface AtomicAction {
+    /**
+     * Performs the action. Behavior should be all-or-nothing: if the action doesn't succeed, it
+     * should restore any temporary state to what it was before, before throwing an exception.
+     * @throws Exception
+     */
+    void perform() throws ActionException;
+
+    /**
+     * Backs out the completed action. This will be called if a subsequent action has failed.
+     * @throws Exception
+     */
+    void backout() throws ActionException;
+
+    /**
+     * Cleans up after all actions have completed. This may involve releasing/deleting
+     * any temporary resources being kept around to fulfil a backOut request.
+     * @throws Exception
+     */
+    void cleanup() throws ActionException;
+}

--- a/src/main/java/com/couchbase/lite/support/security/SymmetricKey.java
+++ b/src/main/java/com/couchbase/lite/support/security/SymmetricKey.java
@@ -71,7 +71,7 @@ public class SymmetricKey {
     }
 
     /**
-     * Create a SymmetricKey object with a secure random generated key.
+     * Create an instance with a secure random generated key.
      * @throws SymmetricKeyException
      */
     public SymmetricKey() throws SymmetricKeyException{
@@ -79,7 +79,7 @@ public class SymmetricKey {
     }
 
     /**
-     * Create a SymmetricKey object with a password, a salt, and number of iterating rounds
+     * Create an instance with a password, a salt, and number of iterating rounds
      * for deriving a PBKDF2 secret key.
      * @param password Password
      * @param salt Salt
@@ -87,6 +87,55 @@ public class SymmetricKey {
      * @throws SymmetricKeyException
      */
     public SymmetricKey(String password, byte[] salt, int rounds) throws SymmetricKeyException {
+        initWithPassword(password, salt, rounds);
+    }
+
+    /**
+     * Create an instance with a password. The constructor will use the default salt and
+     * number of iterating rounds when deriving a PBKDF2 secret key.
+     * @param password Password
+     * @throws SymmetricKeyException
+     */
+    public SymmetricKey(String password) throws SymmetricKeyException {
+        initWithPassword(password, DEFAULT_KEY_SALT.getBytes(), DEFAULT_KEY_ROUNDS);
+    }
+
+    /**
+     * Create an instance with a raw key. The size of the key needs to be 32 bytes.
+     * @param key
+     * @throws SymmetricKeyException
+     */
+    public SymmetricKey(byte[] key) throws SymmetricKeyException {
+        initWithKey(key);
+    }
+
+    /**
+     * Creates an instance with a raw key or a password string. The size of the key needs to
+     * be 32 bytes
+     * @param keyOrPassword Key or password
+     * @throws SymmetricKeyException
+     */
+    public SymmetricKey(Object keyOrPassword) throws SymmetricKeyException {
+        if (keyOrPassword instanceof String) {
+            initWithPassword((String)keyOrPassword, DEFAULT_KEY_SALT.getBytes(), DEFAULT_KEY_ROUNDS);
+        } else {
+            if (!(keyOrPassword instanceof byte[])) {
+                throw new IllegalArgumentException("Key must be String or byte[32]");
+            }
+            initWithKey((byte[])keyOrPassword);
+        }
+    }
+
+    /**
+     * Initialize the object with a password, sales, and number of rounds for deriving
+     * the password into a raw key by using 64,000 rounds of PBKDF2 hashing.
+     * @param password Password
+     * @param salt Salt
+     * @param rounds Number of rounds
+     * @throws SymmetricKeyException
+     */
+    private void initWithPassword(String password, byte[] salt, int rounds)
+            throws SymmetricKeyException {
         if (password == null)
             throw new SymmetricKeyException("Password cannot be null.");
         if (salt.length < MIN_KEY_SALT_SIZE)
@@ -104,21 +153,11 @@ public class SymmetricKey {
     }
 
     /**
-     * Create a SymmetricKey object with a password. The constructor will use the default salt and
-     * number of iterating rounds when deriving a PBKDF2 secret key.
-     * @param password Password
+     * Initialize the object with a raw key of 32 bytes size.
+     * @param key 32 bytes raw key
      * @throws SymmetricKeyException
      */
-    public SymmetricKey(String password) throws SymmetricKeyException {
-        this(password, DEFAULT_KEY_SALT.getBytes(), DEFAULT_KEY_ROUNDS);
-    }
-
-    /**
-     * Create a SymmetricKey object with a raw key. The size of the key needs to be 32 bytes.
-     * @param key
-     * @throws SymmetricKeyException
-     */
-    public SymmetricKey(byte[] key) throws SymmetricKeyException {
+    private void initWithKey(byte[] key) throws SymmetricKeyException {
         if (key == null)
             throw new SymmetricKeyException("Key cannot be null");
         if (key.length != KEY_SIZE)

--- a/src/main/java/com/couchbase/lite/util/Log.java
+++ b/src/main/java/com/couchbase/lite/util/Log.java
@@ -44,6 +44,7 @@ public class Log {
     public static final String TAG_MULTI_STREAM_WRITER = "MultistreamWriter";
     public static final String TAG_BLOB_STORE = "BlobStore";
     public static final String TAG_SYMMETRIC_KEY = "SymmetricKey";
+    public static final String TAG_ACTION = "Action";
 
 
     /**
@@ -71,6 +72,7 @@ public class Log {
         enabledTags.put(Log.TAG_MULTI_STREAM_WRITER, WARN);
         enabledTags.put(Log.TAG_BLOB_STORE, WARN);
         enabledTags.put(Log.TAG_SYMMETRIC_KEY, WARN);
+        enabledTags.put(Log.TAG_ACTION, WARN);
     }
 
     /**


### PR DESCRIPTION
- Implemented SQLite database and attachment rekey
- API Change:
[Added] Database.changeEncryptionKey(final Object newKeyOrPassword)
[Added] Manager.registerEncryptionKey(Object keyOrPassword, String databaseName)
[Removed] Manager.registerEncryptionKey(String password, String databaseName)
[Removed] Manager.registerEncryptionKey(byte[] keys, String databaseName)
[Added] Context.getTempDir()

#719 #720