### PR TITLE
Fixed #781 added code to handle the case of large file

### DIFF
--- a/src/main/java/com/couchbase/lite/BlobStore.java
+++ b/src/main/java/com/couchbase/lite/BlobStore.java
@@ -558,13 +558,17 @@ public class BlobStore {
         try {
             is = new FileInputStream(file);
 
-            // Get the size of the file
+            // Get the size of the file:
             long length = file.length();
+            if (length > (long)Integer.MAX_VALUE)
+                throw new OutOfMemoryError("The file is too large to read into a byte array.");
 
-            // Create the byte array to hold the data
+            // Create the byte array to hold the data:
             byte[] bytes = new byte[(int) length];
+            if (bytes == null)
+                throw new OutOfMemoryError("The file is too large to read into a byte array.");
 
-            // Read in the bytes
+            // Read in the bytes:
             int offset = 0;
             int numRead = 0;
             while (offset < bytes.length
@@ -573,9 +577,8 @@ public class BlobStore {
             }
 
             // Ensure all the bytes have been read in
-            if (offset < bytes.length) {
+            if (offset < bytes.length)
                 throw new IOException("Could not completely read file " + file.getName());
-            }
             return bytes;
         } finally {
              if (is != null)

--- a/src/main/java/com/couchbase/lite/BlobStore.java
+++ b/src/main/java/com/couchbase/lite/BlobStore.java
@@ -445,6 +445,9 @@ public class BlobStore {
                 Log.w(Log.TAG_DATABASE, "BlobStore: Attachment " + path + " decoded incorrectly!");
                 blob = null;
             }
+        } catch (OutOfMemoryError e) {
+            blob = null;
+            Log.e(Log.TAG_DATABASE, "BlobStore: Error reading file", e);
         } catch (IOException e) {
             blob = null;
             Log.e(Log.TAG_DATABASE, "BlobStore: Error reading file", e);


### PR DESCRIPTION
I have checked the implementation of Java7's Files.readAllBytes() and the implementation throws OOM exception if the size is larger than Interger.MAX so I did the same thing. Also per @hideki suggested, I also added a check for null value when creating a byte array object to throw OOM exception if it's null.

Reference: http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7-b147/java/nio/file/Files.java#Files.readAllBytes%28java.nio.file.Path%29

#781