### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/683

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -152,4 +152,8 @@ public class Body {
         this.object = null;
         this.json = null;
     }
+
+    public boolean hasContent() {
+        return this.object != null && this.json != null;
+    }
 }


### PR DESCRIPTION
DocumentChange of Database.ChangeEvent might not contain revision body. In case of include_docs=true, needs to load revision body

Test is done by Sync Gateway, https://github.com/couchbase/couchbase-lite-android-liteserv and Curl command [Makefile](https://gist.github.com/hideki/823c1c02157a3f9f1b2f)