### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/683

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -515,8 +515,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     }
                 }
 
-                if(rev.getBody() != null) rev.getBody().release();
-
                 // Mark this revision's fake sequence as processed:
                 pendingSequences.removeSequence(fakeSequence);
             }


### PR DESCRIPTION
Inserted revision body by pull replication could be accessed from other codes. In case of the https://github.com/couchbase/couchbase-lite-android/issues/683 , `/_changes?include_docs=true` access revision body.

`if(rev.getBody() != null) rev.getBody().release();` was added to reduce memory usage during pull replication, but it should not be added here.