### PR TITLE
Fixed #435 One shot replicator sends STOPPING state immediately

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -797,8 +797,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         Log.d(Log.TAG_SYNC, "changeTrackerStopped.  lifecycle: %s", lifecycle);
         switch (lifecycle) {
             case ONESHOT:
-                // TODO: This is too early to fire STOP_GRACEFUL, Need to change.
-                Log.d(Log.TAG_SYNC, "fire STOP_GRACEFUL");
                 if (tracker.getLastError() != null) {
                     setError(tracker.getLastError());
                 }
@@ -943,11 +941,11 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         }
 
         // continuous mode, make state IDLE
-        if(isContinuous()) {
+        if (isContinuous()) {
             fireTrigger(ReplicationTrigger.WAITING_FOR_CHANGES);
         }
         // one shot mode, make state STOPPING
-        else{
+        else {
             triggerStopGraceful();
         }
 

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -179,11 +179,11 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                 //       This is reason to check if queue is empty.
                 if (pendingFutures.isEmpty()) {
                     Log.v(Log.TAG_SYNC, "[waitForPendingFutures()] state=" + stateMachine.getState());
-                    if(isContinuous()) {
+                    if (isContinuous()) {
                         // Make state IDLE
                         Log.v(Log.TAG_SYNC, "[waitForPendingFutures()] fireTrigger(ReplicationTrigger.WAITING_FOR_CHANGES);");
                         fireTrigger(ReplicationTrigger.WAITING_FOR_CHANGES);
-                    }else{
+                    } else {
                         // Make state STOPPING
                         triggerStopGraceful();
                     }

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -282,7 +282,7 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
     @InterfaceAudience.Public
     public void stop() {
         if (replicationInternal != null) {
-            replicationInternal.triggerStop();
+            replicationInternal.triggerStopGraceful();
         }
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -854,11 +854,10 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                     setError(e);
 
                     // TODO: double check this behavior against iOS implementation, especially
-                    // TODO: with regards to behavior of a continuous replication.
+                    //       with regards to behavior of a continuous replication.
                     // Note: was added in order that unit test testRunReplicationWithError() finished and passed.
-                    // (before adding this, the replication would just end up in limbo and never finish)
-                    fireTrigger(ReplicationTrigger.STOP_GRACEFUL);  // TODO: call triggerStopGraceful(); just to be more consistent
-
+                    //       (before adding this, the replication would just end up in limbo and never finish)
+                    triggerStopGraceful();
                 } else {
                     if (e != null && Utils.is404(e)) {
                         Log.v(Log.TAG_SYNC, "%s: Remote checkpoint does not exist on server yet: %s",


### PR DESCRIPTION
- In case of One Shot replication,  STOP_GRACEFUL is fired almost immediately. It makes replicator state STOPPING instead of RUNNING during replication.
- Like continuous replication mode, use waitForPendingStates() to wait till all tasks are completed, then fire STOP_GRACEFULLY at end of waitForPendingState() if mode is OneShot