### PR TITLE
Fixed #809 - Jenkins: testMockPullBulkDocsSyncGw fails on Jenkins

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -89,7 +89,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected Map<String, Object> requestHeaders;
     private String serverType;
     protected Batcher<RevisionInternal> batcher;
-    protected static final int PROCESSOR_DELAY = 500;
+    protected static int PROCESSOR_DELAY = 500;
     protected static int INBOX_CAPACITY = 100;
     protected ScheduledExecutorService remoteRequestExecutor;
     protected Throwable error;


### PR DESCRIPTION
It seems 500ms is too short for delay time of Batcher on slow device environment. Because of it, Batcher executes before inbox becomes full. For testing purpose, set 5sec to delay time.

NOTE: This does not cause test slowness