### PR TITLE
Fixed #838 - testContinuousPushReplicationGoesIdle hangs on Jenkins

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -856,14 +856,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     @Override
     public void changeTrackerCaughtUp() {
         Log.d(Log.TAG_SYNC, "changeTrackerCaughtUp");
-        // for continuous replications, once the change tracker is caught up, we
-        // should try to go into the idle state.
-        if (isContinuous()) {
-            // this has to be on a different thread than the replicator thread, or else it's a deadlock
-            // because it might be waiting for jobs that have been scheduled, and not
-            // yet executed (and which will never execute because this will block processing).
-            waitForPendingFuturesWithNewThread();
-        }
+        // this has to be on a different thread than the replicator thread, or else it's a deadlock
+        // because it might be waiting for jobs that have been scheduled, and not
+        // yet executed (and which will never execute because this will block processing).
+        waitForPendingFuturesWithNewThread();
     }
 
     /**


### PR DESCRIPTION
- During debugging for #838, single shot replication might fail to stop itself. It could be caused by failing to handle some events to make single shot replication waits for replication finish and sends STOPPING state. By this change, it gives more chance to handle event correctly.