### PR TITLE
Fixed #573 - Port Replication.stop() method from iOS

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -891,10 +891,21 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     }
 
     @Override
-    protected void stopGraceful() {
-        super.stopGraceful();
+    protected void stop() {
+        if (stateMachine.isInState(ReplicationState.STOPPED))
+            return;
 
-        Log.d(Log.TAG_SYNC, "PullerInternal.stopGraceful() started");
+        Log.d(Log.TAG_SYNC, "%s STOPPING...", toString());
+
+        // stop change tracker
+        if (changeTracker != null)
+            changeTracker.stop();
+
+        // clear downloadsToInsert batcher.
+        if (downloadsToInsert != null)
+            downloadsToInsert.flushAll();
+
+        super.stop();
 
         // this has to be on a different thread than the replicator thread, or else it's a deadlock
         // because it might be waiting for jobs that have been scheduled, and not
@@ -905,21 +916,13 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                 try {
                     // wait for all tasks completed
                     waitForAllTasksCompleted();
-
-                    // stop change tracker
-                    if (changeTracker != null) {
-                        Log.d(Log.TAG_SYNC, "stopping change tracker");
-                        changeTracker.stop();
-                        Log.d(Log.TAG_SYNC, "stopped change tracker");
-                    }
                 } catch (Exception e) {
-                    Log.e(Log.TAG_SYNC, "stopGraceful.run() had exception: %s", e);
-                    e.printStackTrace();
+                    Log.e(Log.TAG_SYNC, "stop.run() had exception: %s", e);
                 } finally {
                     // stop replicator immediate
                     triggerStopImmediate();
+                    Log.d(Log.TAG_SYNC, "PullerInternal stop.run() finished");
                 }
-                Log.d(Log.TAG_SYNC, "PullerInternal stopGraceful.run() finished");
             }
         }).start();
     }

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -268,12 +268,9 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      */
     @InterfaceAudience.Public
     public boolean isRunning() {
-        if (replicationInternal == null) {
+        if (replicationInternal == null)
             return false;
-        }
-        return replicationInternal.stateMachine.isInState(ReplicationState.RUNNING) ||
-                replicationInternal.stateMachine.isInState(ReplicationState.IDLE) ||
-                replicationInternal.stateMachine.isInState(ReplicationState.OFFLINE);
+        return replicationInternal.isRunning();
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1041,7 +1041,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         // cancel all pending future tasks.
         while (!pendingFutures.isEmpty()) {
             Future future = pendingFutures.poll();
-            if (future != null && !future.isCancelled() && future.isDone()) {
+            if (future != null && !future.isCancelled() && !future.isDone()) {
                 future.cancel(true);
             }
         }


### PR DESCRIPTION
Instead of wait till replicator state becomes IDLE, stop() tries to stop as soon as possible.