### PR TITLE
Fixed #830 - Replication should stop immediately if error is not tran…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -322,8 +322,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                                 queueDownloadedRevision(rev);
                             } else {
                                 Status status = statusFromBulkDocsResponseItem(props);
-                                error = new CouchbaseLiteException(status);
-                                revisionFailed(rev, error);
+                                Throwable err = new CouchbaseLiteException(status);
+                                setError(err);
+                                revisionFailed(rev, err);
                             }
                         }
                     },

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -734,7 +734,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
     private void uploadJsonRevision(final RevisionInternal rev) {
         // Get the revision's properties:
         if (!db.inlineFollowingAttachmentsIn(rev)) {
-            error = new CouchbaseLiteException(Status.BAD_ATTACHMENT);
+            setError(new CouchbaseLiteException(Status.BAD_ATTACHMENT));
             return;
         }
 

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -92,7 +92,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected static int PROCESSOR_DELAY = 500;
     protected static int INBOX_CAPACITY = 100;
     protected ScheduledExecutorService remoteRequestExecutor;
-    protected Throwable error;
+    private Throwable error; // use private to make sure if error is set through setError()
     private String remoteCheckpointDocID;
     protected Map<String, Object> remoteCheckpoint;
     protected AtomicInteger completedChangesCount;
@@ -103,7 +103,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     private boolean lastSequenceChanged = false;
     private boolean savingCheckpoint;
     private boolean overdueForCheckpointSave;
-
 
     // the code assumes this is a _single threaded_ work executor.
     // if it's not, the behavior will be buggy.  I don't see a way to assert this in the code.
@@ -370,20 +369,20 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         Future future = sendAsyncRequest("GET", sessionPath, null, new RemoteRequestCompletionBlock() {
 
             @Override
-            public void onCompletion(HttpResponse httpResponse, Object result, Throwable error) {
+            public void onCompletion(HttpResponse httpResponse, Object result, Throwable err) {
 
                 try {
-                    if (error != null) {
+                    if (err != null) {
                         // If not at /db/_session, try CouchDB location /_session
-                        if (error instanceof HttpResponseException &&
-                                ((HttpResponseException) error).getStatusCode() == 404 &&
+                        if (err instanceof HttpResponseException &&
+                                ((HttpResponseException) err).getStatusCode() == 404 &&
                                 sessionPath.equalsIgnoreCase("/_session")) {
 
                             checkSessionAtPath("_session");
                             return;
                         }
-                        Log.e(Log.TAG_SYNC, this + ": Session check failed", error);
-                        setError(error);
+                        Log.e(Log.TAG_SYNC, this + ": Session check failed", err);
+                        setError(err);
 
                     } else {
                         Map<String, Object> response = (Map<String, Object>) result;
@@ -450,27 +449,29 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     @InterfaceAudience.Private
     protected void setError(Throwable throwable) {
 
-        // TODO
-        /*
-        if (error.code == NSURLErrorCancelled && $equal(error.domain, NSURLErrorDomain))
-            return;
-         */
+        // TODO - needs to port
+        //if (error.code == NSURLErrorCancelled && $equal(error.domain, NSURLErrorDomain))
+        //    return;
 
-        if (throwable != error) {
+        if (throwable != this.error) {
             Log.e(Log.TAG_SYNC, "%s: Progress: set error = %s", this, throwable);
             parentReplication.setLastError(throwable);
-            error = throwable;
-            Replication.ChangeEvent changeEvent = new Replication.ChangeEvent(this);
-            changeEvent.setError(error);
-            notifyChangeListeners(changeEvent);
+            this.error = throwable;
+
+            // if permanent error, stop immediately
+            if(Utils.isPermanentError(this.error)) {
+                stop();
+            }
+
+            // iOS version sends notification from stop() method, but java version does not.
+            // following codes are always executed.
+            {
+                Replication.ChangeEvent changeEvent = new Replication.ChangeEvent(this);
+                changeEvent.setError(this.error);
+                notifyChangeListeners(changeEvent);
+            }
         }
-
-        // #352
-        // iOS version: stop replicator immediately when call setError() with permanent error.
-        // But, for Core Java, some of codes wait IDLE state. So this is reason to wait till
-        // state becomes IDLE.
     }
-
 
     @InterfaceAudience.Private
     protected void addToCompletedChangesCount(int delta) {
@@ -1191,8 +1192,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 // iOS version: stop replicator immediately when call setError() with permanent error.
                 // But, for Core Java, some of codes wait IDLE state. So this is reason to wait till
                 // state becomes IDLE.
-                if (Utils.isPermanentError(error) && isContinuous()) {
-                    Log.d(Log.TAG_SYNC, "IDLE: triggerStopGraceful() " + error.toString());
+                if (Utils.isPermanentError(ReplicationInternal.this.error) && isContinuous()) {
+                    Log.d(Log.TAG_SYNC, "IDLE: triggerStopGraceful() " + ReplicationInternal.this.error.toString());
                     triggerStopGraceful();
                 }
             }
@@ -1327,7 +1328,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected void retry() {
         Log.v(Log.TAG_SYNC, "[retry()]");
         retryCount++;
-        error = null;
+        this.error = null;
         checkSession();
     }
 
@@ -1379,7 +1380,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         }
 
         // IDLE_OK
-        if (error == null) {
+        if (this.error == null) {
             retryCount = 0;
         }
         // IDLE_ERROR
@@ -1390,8 +1391,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 if (isContinuous()) {
                     // 12/16/2014 - only retry if error is transient error 50x http error
                     // It may need to retry for any kind of errors
-                    if (Utils.isTransientError(error)) {
-
+                    if (Utils.isTransientError(this.error)) {
                         cancelRetryFuture();
                         scheduleRetryFuture();
                     }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -465,11 +465,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
             // iOS version sends notification from stop() method, but java version does not.
             // following codes are always executed.
-            {
-                Replication.ChangeEvent changeEvent = new Replication.ChangeEvent(this);
-                changeEvent.setError(this.error);
-                notifyChangeListeners(changeEvent);
-            }
+            Replication.ChangeEvent changeEvent = new Replication.ChangeEvent(this);
+            changeEvent.setError(this.error);
+            notifyChangeListeners(changeEvent);
         }
     }
 

--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -146,7 +146,9 @@ public class Batcher<T> {
     public void clear() {
         unschedule();
         inbox.clear();
-        inbox.notify();
+        synchronized (inbox) {
+            inbox.notify();
+        }
     }
 
     public void waitForPendingFutures() {

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -56,20 +56,18 @@ public class Utils {
         }
     }
 
-    /**
-     * in CBLMisc.m
-     * BOOL CBLIsPermanentError( NSError* error )
-     */
     public static boolean isPermanentError(int code) {
-        // TODO: make sure if 406 is acceptable error
         // 406 - in Test cases, server return 406 because of CouchDB API
         //       http://docs.couchdb.org/en/latest/api/database/bulk-api.html
         //       GET /{db}/_all_docs or POST /{db}/_all_docs
         return (code >= 400 && code <= 405) || (code >= 407 && code <= 499);
     }
 
+    /**
+     * in CBLMisc.m
+     * BOOL CBLMayBeTransientError( NSError* error )
+     */
     public static boolean isTransientError(Throwable throwable) {
-
         if (throwable instanceof CouchbaseLiteException) {
             CouchbaseLiteException e = (CouchbaseLiteException) throwable;
             return isTransientError(e.getCBLStatus().getCode());
@@ -79,9 +77,7 @@ public class Utils {
         } else {
             return false;
         }
-
     }
-
 
     public static boolean isTransientError(StatusLine status) {
 
@@ -97,12 +93,10 @@ public class Utils {
     }
 
     public static boolean isTransientError(int statusCode) {
-
         if (statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504) {
             return true;
         }
         return false;
-
     }
 
     /**


### PR DESCRIPTION
…sient error.

In case permanent error occurs during replication, replication keeps to replicate till it becomes IDLE state. Instead, it immediately stops replication if error is permanent.

Additional:
- Batcher.java: `Object.notify()` should be called in `synchronization` block
- Utils.java: code cleanup