### PR TITLE
Fixed #847 Rename sqlite and sqlicpher native library

### DIFF
--- a/src/main/java/com/couchbase/lite/storage/SQLiteNativeLibrary.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteNativeLibrary.java
@@ -23,17 +23,17 @@ public class SQLiteNativeLibrary {
     private static final String TAG = Log.TAG_DATABASE;
 
     // JNI Native libraries:
-    public static final String JNI_SQLITE_SYSTEM_LIBRARY = "CBLJavaNativeSQLiteSystem";
-    public static final String JNI_SQLITE_CUSTOM_LIBRARY = "CBLJavaNativeSQLite";
-    public static final String JNI_SQLCIPHER_LIBRARY = "CBLJavaNativeSQLCipher";
+    public static final String JNI_SQLITE_DEFAULT_LIBRARY = "cbljavasqlitedefault";
+    public static final String JNI_SQLITE_CUSTOM_LIBRARY = "cbljavasqlitecustom";
+    public static final String JNI_SQLCIPHER_LIBRARY = "cbljavasqlcipher";
     public static final String[] NATIVE_LIBRARY_OPTIONS =
-            {JNI_SQLCIPHER_LIBRARY, JNI_SQLITE_CUSTOM_LIBRARY, JNI_SQLITE_SYSTEM_LIBRARY};
+            {JNI_SQLCIPHER_LIBRARY, JNI_SQLITE_CUSTOM_LIBRARY, JNI_SQLITE_DEFAULT_LIBRARY};
 
     // Use this to override auto loading native libraries:
     public static String TEST_NATIVE_LIBRARY_NAME = null;
 
     // JNI Key Derivation Native library:
-    private static final String JNI_KEY_LIBRARY = "CBLJavaNativeKey";
+    private static final String JNI_KEY_LIBRARY = "cbljavakey";
 
     // SQLite library:
     private static final String SHARED_ANDROID_SQLITE_LIBRARY = "sqlite";
@@ -62,7 +62,7 @@ public class SQLiteNativeLibrary {
             } else if (JNI_SQLITE_CUSTOM_LIBRARY.equals(libName)) {
                 if (load(SHARED_SQLITE_LIBRARY))
                     success = load(libName);
-            } else if (JNI_SQLITE_SYSTEM_LIBRARY.equals(libName)) {
+            } else if (JNI_SQLITE_DEFAULT_LIBRARY.equals(libName)) {
                 if (isAndriod()) {
                     if (load(SHARED_ANDROID_SQLITE_LIBRARY))
                         success = load(libName);


### PR DESCRIPTION
Per package renaming, binary names have been simplified and now all lower-cased.

#847