### PR TITLE
Fixed #728 - Replicator should not stop by missing revisions

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -323,7 +323,6 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             } else {
                                 Status status = statusFromBulkDocsResponseItem(props);
                                 Throwable err = new CouchbaseLiteException(status);
-                                setError(err);
                                 revisionFailed(rev, err);
                             }
                         }


### PR DESCRIPTION
- setError(Throwable) stops replicator if error is permanent error. In this case, it should be checked by if error is transient. IsTransient() is called from revisionFailed().

iOS implementation
https://github.com/couchbase/couchbase-lite-ios/blob/master/Source/CBLRestPuller.m#L529-L530