### PR TITLE
Fixed #688 Make getTotalRows public

### DIFF
--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -177,6 +177,20 @@ public final class View implements ViewStoreDelegate {
     }
 
     /**
+     * Get total number of rows in the view. The view's index will be updated if needed
+     * before returning the value.
+     */
+    @InterfaceAudience.Public
+    public int getTotalRows() {
+        try {
+            updateIndex();
+        } catch (CouchbaseLiteException e) {
+            Log.e(Log.TAG_VIEW, "Update index failed when getting the total rows", e);
+        }
+        return getCurrentTotalRows();
+    }
+
+    /**
      * Get the last sequence number indexed so far.
      */
     @InterfaceAudience.Public
@@ -252,7 +266,7 @@ public final class View implements ViewStoreDelegate {
     ///////////////////////////////////////////////////////////////////////////
 
     @InterfaceAudience.Private
-    public int getTotalRows() {
+    public int getCurrentTotalRows() {
         return viewStore.getTotalRows();
     }
 

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -2089,7 +2089,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
 
         Map<String, Object> responseBody = new HashMap<String, Object>();
         responseBody.put("rows", rows);
-        responseBody.put("total_rows", view.getTotalRows());
+        responseBody.put("total_rows", view.getCurrentTotalRows());
         responseBody.put("offset", options.getSkip());
         if (options.isUpdateSeq()) {
             responseBody.put("update_seq", lastSequenceIndexed);


### PR DESCRIPTION
- Made getTotalRows public
- Update index before returning the value
- Changed Router's querying design docs to call getCurrentTotalRows()

#688