### PR TITLE
Fixed #695 Implemented Replicator.remoteUUID API

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -678,6 +678,11 @@ public final class Manager {
                 }
             }
 
+            String remoteUUID = (String) properties.get("remoteUUID");
+            if (remoteUUID != null) {
+                repl.setRemoteUUID(remoteUUID);
+            }
+
             if (push) {
                 repl.setCreateTarget(createTarget);
             }

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -87,7 +87,8 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
         DOC_IDS,
         REQUEST_HEADERS,
         AUTHENTICATOR,
-        CREATE_TARGET
+        CREATE_TARGET,
+        REMOTE_UUID
     }
 
     /**
@@ -700,6 +701,31 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
         replicationInternal.deleteCookie(name);
     }
 
+    /**
+     * Get the remote UUID representing the remote server.
+     */
+    @InterfaceAudience.Public
+    public String getRemoteUUID() {
+        return replicationInternal.getRemoteUUID();
+    }
+
+    /**
+     * Set the remote UUID representing the remote server.
+     *
+     * In some cases, especially Peer-to-peer replication, the remote or target database
+     * might not have a fixed URL - The hostname or IP address or port could change.
+     * As a result, URL couldn't be used to represent the remote database when persistently
+     * identifying the replication. In such cases, set a remote unique identifier to represent
+     * the remote database.
+     *
+     * @param remoteUUID remote unique identifier
+     */
+    @InterfaceAudience.Public
+    public void setRemoteUUID(String remoteUUID) {
+        properties.put(ReplicationField.REMOTE_UUID, remoteUUID);
+        replicationInternal.setRemoteUUID(remoteUUID);
+    }
+
     @InterfaceAudience.Private
     protected HttpClientFactory getClientFactory() {
         return replicationInternal.getClientFactory();
@@ -827,11 +853,8 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      * @param replicationInternal
      */
     private void addProperties(ReplicationInternal replicationInternal) {
-
         for (ReplicationField key : properties.keySet()) {
-
             Object value = properties.get(key);
-
             switch (key) {
                 case FILTER_NAME:
                     replicationInternal.setFilter((String)value);
@@ -851,6 +874,8 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
                 case REQUEST_HEADERS:
                     replicationInternal.setHeaders((Map)value);
                     break;
+                case REMOTE_UUID:
+                    replicationInternal.setRemoteUUID((String)value);
             }
         }
     }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -86,6 +86,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected String filterName;
     protected Map<String, Object> filterParams;
     protected List<String> documentIDs;
+    private String remoteUUID;
     protected Map<String, Object> requestHeaders;
     private String serverType;
     protected Batcher<RevisionInternal> batcher;
@@ -907,7 +908,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     }
 
     public String remoteCheckpointDocID(String localUUID) {
-
         // canonicalization: make sure it produces the same checkpoint id regardless of
         // ordering of filterparams / docids
         Map<String, Object> filterParamsCanonical = null;
@@ -924,7 +924,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         // use a treemap rather than a dictionary for purposes of canonicalization
         Map<String, Object> spec = new TreeMap<String, Object>();
         spec.put("localUUID", localUUID);
-        spec.put("remoteURL", remote.toExternalForm());
         spec.put("push", !isPull());
         spec.put("continuous", isContinuous());
         if (getFilter() != null) {
@@ -935,6 +934,11 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         }
         if (docIdsSorted != null) {
             spec.put("docids", docIdsSorted);
+        }
+        if (remoteUUID != null) {
+            spec.put("remoteUUID", remoteUUID);
+        } else {
+            spec.put("remoteURL", remote.toExternalForm());
         }
 
         byte[] inputBytes = null;
@@ -1003,6 +1007,19 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         this.filterParams = filterParams;
     }
 
+    /**
+     * Get the remoteUUID representing the remote server.
+     */
+    public String getRemoteUUID() {
+        return remoteUUID;
+    }
+
+    /**
+     * Set the remoteUUID representing the remote server.
+     */
+    public void setRemoteUUID(String remoteUUID) {
+        this.remoteUUID = remoteUUID;
+    }
 
     abstract protected void processInbox(RevisionList inbox);
 


### PR DESCRIPTION
Implemented Replicator.remoteUUID used for representing the remote database instead of URL for the cases (e.g. P2P) that the URLs are not static.

#695