### PR TITLE
Fixed #535 : setting documentIDs not working in Push replication

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -254,9 +254,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
             maxPendingSequence = new Long(0);
         }
 
-        if (filterName != null) {
-            filter = db.getFilter(filterName);
-        }
+        filter = compilePushReplicationFilter();
         if (filterName != null && filter == null) {
             Log.w(Log.TAG_SYNC, "%s: No ReplicationFilter registered for filter '%s'; ignoring",
                     this, filterName);

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  * The external facade for the Replication API
  */
 public class Replication implements ReplicationInternal.ChangeListener, NetworkReachabilityListener {
-
     /**
      * Enum to specify which direction this replication is going (eg, push vs pull)
      *
@@ -172,7 +171,6 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      */
     @InterfaceAudience.Public
     public void start() {
-
         if (replicationInternal == null) {
             initReplicationInternal();
         } else {
@@ -199,7 +197,6 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
                 }
             });
         }
-
 
         replicationInternal.triggerStart();
     }
@@ -380,7 +377,6 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      */
     @Override
     public void changed(ChangeEvent event) {
-
         // forget cached IDs (Should be executed in workExecutor)
         if (pendingDocIDs != null) {
             db.runAsync(new AsyncTask() {
@@ -451,13 +447,10 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
                 @Override
                 public void run() {
                     try {
-                        String filterName = (String) properties.get("filter");
-                        Map<String, Object> filterParams = (Map<String, Object>) properties.get("query_params");
-                        ReplicationFilter filter = null;
-                        if (filterName != null) {
-                            filter = db.getFilter(filterName);
-                        }
-
+                        Map<String, Object> filterParams =
+                                (Map<String, Object>) properties.get("query_params");
+                        ReplicationFilter filter =
+                                replicationInternal.compilePushReplicationFilter();
                         String lastSequence = replicationInternal.lastSequence;
                         if (lastSequence == null)
                             lastSequence = db.lastSequenceWithCheckpointId(remoteCheckpointDocID());
@@ -641,16 +634,16 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      * Sets the documents to specify as part of the replication.
      */
     @InterfaceAudience.Public
-    public void setDocIds(List<String> docIds) {
+    public void setDocumentIDs(List<String> docIds) {
         properties.put(ReplicationField.DOC_IDS, docIds);
-        replicationInternal.setDocIds(docIds);
+        replicationInternal.setDocumentIDs(docIds);
     }
 
     /**
      * Gets the documents to specify as part of the replication.
      */
-    public List<String> getDocIds() {
-        return replicationInternal.getDocIds();
+    public List<String> getDocumentIDs() {
+        return replicationInternal.getDocumentIDs();
     }
 
     /**
@@ -863,7 +856,7 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
                     replicationInternal.setFilterParams((Map)value);
                     break;
                 case DOC_IDS:
-                    replicationInternal.setDocIds((List)value);
+                    replicationInternal.setDocumentIDs((List)value);
                     break;
                 case AUTHENTICATOR:
                     replicationInternal.setAuthenticator((Authenticator)value);

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -634,16 +634,16 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      * Sets the documents to specify as part of the replication.
      */
     @InterfaceAudience.Public
-    public void setDocumentIDs(List<String> docIds) {
+    public void setDocIds(List<String> docIds) {
         properties.put(ReplicationField.DOC_IDS, docIds);
-        replicationInternal.setDocumentIDs(docIds);
+        replicationInternal.setDocIds(docIds);
     }
 
     /**
      * Gets the documents to specify as part of the replication.
      */
-    public List<String> getDocumentIDs() {
-        return replicationInternal.getDocumentIDs();
+    public List<String> getDocIds() {
+        return replicationInternal.getDocIds();
     }
 
     /**
@@ -856,7 +856,7 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
                     replicationInternal.setFilterParams((Map)value);
                     break;
                 case DOC_IDS:
-                    replicationInternal.setDocumentIDs((List)value);
+                    replicationInternal.setDocIds((List)value);
                     break;
                 case AUTHENTICATOR:
                     replicationInternal.setAuthenticator((Authenticator)value);

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -918,8 +918,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         }
 
         List<String> docIdsSorted = null;
-        if (getDocumentIDs() != null) {
-            docIdsSorted = new ArrayList<String>(getDocumentIDs());
+        if (getDocIds() != null) {
+            docIdsSorted = new ArrayList<String>(getDocIds());
             Collections.sort(docIdsSorted);
         }
 
@@ -999,14 +999,14 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     /**
      * Gets the documents to specify as part of the replication.
      */
-    public List<String> getDocumentIDs() {
+    public List<String> getDocIds() {
         return documentIDs;
     }
 
     /**
      * Sets the documents to specify as part of the replication.
      */
-    public void setDocumentIDs(List<String> docIds) {
+    public void setDocIds(List<String> docIds) {
         documentIDs = docIds;
     }
 


### PR DESCRIPTION
Implemented documentID filtering for push replication.

#535