### PR TITLE
Fix batcher synchronization

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -966,8 +966,13 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             changeTracker.stop();
 
         // clear downloadsToInsert batcher.
-        if (downloadsToInsert != null)
-            downloadsToInsert.flushAll();
+        if (downloadsToInsert != null) {
+            // Not waiting here to avoid deadlock as this method is executed
+            // inside the same WorkExecutor as the downloadsToInsert batcher.
+            // All scheduled objects will be waited to completed by calling
+            // waitForAllTasksCompleted() below.
+            downloadsToInsert.flushAll(false);
+        }
 
         super.stop();
 


### PR DESCRIPTION
- Changed to synchronize over mutex.
- When the scheduled task is ready to be processed but there is still a thread keep adding objects to the batcher, give the work executor more chance to work on the task by calling mutex.wait() with a small dealy in queueObjects.
- Fixed incompatible runloop capability when scheduing the task after long pause - instead of schedule with 0 delay, schedule with some small resonable delay to allow more objects to be added to the batcher if available.