### PR TITLE
Fix class cast exception when revpos is a Double

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/AttachmentInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/AttachmentInternal.java
@@ -101,7 +101,7 @@ public class AttachmentInternal {
                 ((Boolean) attachInfo.get("stub")).booleanValue()) {
             // This item is just a stub; validate and skip it
             if (attachInfo.containsKey("revpos")) {
-                int revPos = ((Integer) attachInfo.get("revpos")).intValue();
+                int revPos = ((Number) attachInfo.get("revpos")).intValue();
                 if (revPos <= 0) {
                     throw new CouchbaseLiteException(Status.BAD_ATTACHMENT);
                 }


### PR DESCRIPTION
It seems that _revpos_ can sometimes be a Double and this causes an exception.
If we change the cast to a Number, it all works out well because `Number` also has the `intValue()` method.

We've been using a build with this fix in production in the last couple of months without any issues so I'm pretty sure it's safe. The only thing I'm unsure is why this exception happens in the first place.