### PR TITLE
Fix null id in bulk docs response

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -1199,7 +1199,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                         if (status.isSuccessful()) {
                             result = new HashMap<String, Object>();
                             result.put("ok", true);
-                            result.put("id", docID);
+                            result.put("id", rev.getDocID());
                             if (rev != null) {
                                 result.put("rev", rev.getRevID());
                             }
@@ -1209,11 +1209,11 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                         } else if (status.getCode() == Status.FORBIDDEN) {
                             result = new HashMap<String, Object>();
                             result.put("error", "validation failed");
-                            result.put("id", docID);
+                            result.put("id", rev.getDocID());
                         } else if (status.getCode() == Status.CONFLICT) {
                             result = new HashMap<String, Object>();
                             result.put("error", "conflict");
-                            result.put("id", docID);
+                            result.put("id", rev.getDocID());
                         } else {
                             //return status;  // abort the whole thing if something goes badly wrong
                             return false;


### PR DESCRIPTION
To reproduce the issue:
```
curl -X POST http://172.20.6.40:5984/cblite-test/_bulk_docs -d '{"docs": [{"city": "brighton"}]}'
```
Response:
```
[{"rev":"1-f167f0e9f44ce7cf3c92d53910fb9179","id":null,"ok":true}]
```

Fix: return the id of the revision created. The id will be the one provided by the user or the one generated in the write operation.