### PR TITLE
Fixed #941 - Push Replicator hangs under certain condition

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -450,6 +450,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                             Map<String, Object> properties = null;
                             Map<String, Object> revResults = (Map<String, Object>) results.get(rev.getDocID());
                             if (revResults == null) {
+                                removePending(rev);
                                 continue;
                             }
                             List<String> revs = (List<String>) revResults.get("missing");
@@ -813,9 +814,9 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
     }
 
     private void waitIfPaused(){
-        while (paused) {
-            Log.v(Log.TAG, "Waiting: " + paused);
-            synchronized (pausedObj) {
+        synchronized (pausedObj) {
+            while (paused) {
+                Log.v(Log.TAG, "Waiting: " + paused);
                 try {
                     pausedObj.wait();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
Root Cause: CouchDB and SyncGateway does not return existing doc/revision for  /_revs_diff API if all revisions for doc exist in server. In this case, Push replicator should remove the requested revision id from pendingSequence. But the code did not. As result, pendingSequnce >= MAX makes pull replicator makes wait.