### PR TITLE
Fixed #961 - ReplicationTest failure on Windows by non-closed InputSt…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -666,7 +666,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                     }
 
                     // contentType = null causes Exception from FileBody of apache.
-                    if(contentType == null)
+                    if (contentType == null)
                         contentType = "application/octet-stream"; // default
 
                     // NOTE: Content-Encoding might not be necessary to set. Apache FileBody does not set Content-Encoding.
@@ -717,7 +717,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                     }
                 } finally {
                     // close all inputStreams for Blob
-                    for(InputStream stream: streamList){
+                    for (InputStream stream : streamList) {
                         try {
                             stream.close();
                         } catch (IOException ioe) {
@@ -804,10 +804,10 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
         protected void finalize() throws Throwable {
             // close inputStream after used.
             InputStream stream = getInputStream();
-            if(stream != null){
+            if (stream != null) {
                 try {
                     stream.close();
-                }catch(IOException ioe){
+                } catch (IOException ioe) {
                 }
             }
             super.finalize();


### PR DESCRIPTION
…ream

- InputStream for Blob is not closed, that makes file not delete-able on Windows, and also causes File Descriptor leaks.
- Solution: After pushed files on server, close InputStream. To make sure to close Stream, it is also closed from finalized() of CustomInputStreamBody.

Unit Tested:
- Windows
- OSX
- Linux
- Nexus 6 (6.0.1)
- Genymotion (4.4.4)
