### PR TITLE
Fixed #963 - Cannot pull changes after sync_gateway goes offline, the…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -326,7 +326,8 @@ public class ChangeTracker implements Runnable {
                 Log.v(Log.TAG_CHANGE_TRACKER, "%s: Making request to %s", this, maskedRemoteWithoutCredentials);
                 HttpResponse response = httpClient.execute(request);
                 StatusLine status = response.getStatusLine();
-                if (status.getStatusCode() >= 300 && !Utils.isTransientError(status)) {
+                if ((status.getStatusCode() >= 300 && !Utils.isTransientError(status)) ||
+                        status.getStatusCode() >= 300 && mode != ChangeTrackerMode.LongPoll) {
                     Log.e(Log.TAG_CHANGE_TRACKER, "%s: Change tracker got error %d", this, status.getStatusCode());
                     this.error = new HttpResponseException(status.getStatusCode(), status.getReasonPhrase());
                     break;
@@ -425,7 +426,8 @@ public class ChangeTracker implements Runnable {
                         if (entity != null) {
                             try {
                                 entity.consumeContent();
-                            } catch (IOException e) { }
+                            } catch (IOException e) {
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
…n online

Root Cause : see https://github.com/couchbase/couchbase-lite-java-core/issues/963#issuecomment-177007753

Solution: In case http status is error and  mode is one shot, should not continue to process response for `_changes` API

TEST: I used GrocerySync and SG 1.2 for test.