### PR TITLE
Fixed #964 - ToDoLite crashes during clear Cookie

### DIFF
--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -238,7 +238,8 @@ public class Document {
      */
     @InterfaceAudience.Public
     public Object getProperty(String key) {
-        if (getCurrentRevision().getProperties().containsKey(key)) {
+        if (getCurrentRevision() != null &&
+                getCurrentRevision().getProperties().containsKey(key)) {
             return getCurrentRevision().getProperties().get(key);
         }
         return null;

--- a/src/main/java/com/couchbase/lite/support/PersistentCookieStore.java
+++ b/src/main/java/com/couchbase/lite/support/PersistentCookieStore.java
@@ -164,8 +164,7 @@ public class PersistentCookieStore implements CookieStore {
         try {
             getDb().putLocalDocument(COOKIE_LOCAL_DOC_NAME, null);
         } catch (CouchbaseLiteException e) {
-            Log.e(Log.TAG_SYNC, "Exception saving local doc", e);
-            throw new RuntimeException(e);
+            Log.i(Log.TAG_SYNC, "Unable to clear Cookies: Status=" + e.getCause(), e);
         }
 
         // Clear cookies from local store


### PR DESCRIPTION
- PersistentCookieStore implements CookieStore, and overwrite `clear()` method which is no Exception throws declared. Current code uses RuntimeException to throw Exception even though Exception throws is not declared. However it is bad idea. No caller methods catches `RuntimeException`, then causes application crash. Exception was thrown because cookie was not stored before. So It simply makes clear() method not throw `RuntimeException`.

- During debuting this issue, I also encountered that `Document.getCurrentRevision()` returns `null`. I added null check for `getCurrentRevision()`. Switching user in ToDoLite sample makes switch database, that might be root cause of this issue. Need to investigate ToDoLite also.