### PR TITLE
Uses previously unused variable to avoid expensive duplicate calls.

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -450,10 +450,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             rev = xformed;
 
             // Clean up afterwards
-            Map<String, Object> attachments = (Map<String, Object>) rev.getProperties().get("_attachments");
+            Map<String, Map<String, Object>> attachments = (Map<String, Map<String, Object>>) rev.getProperties().get("_attachments");
 
-            for (Map.Entry<String, Map<String, Object>> entry :
-                    ((Map<String, Map<String, Object>>) rev.getProperties().get("_attachments")).entrySet()) {
+            for (Map.Entry<String, Map<String, Object>> entry : attachments.entrySet()) {
                 Map<String, Object> attachment = entry.getValue();
                 attachment.remove("file");
             }


### PR DESCRIPTION
PullerInternal.queueDownloadedRevision called once into rev's
getProperties and to get for key '_attachments' and put them
into an unused variable. It them immediately made the same
call, with a cast, to entrySet so that it could iterate
over that. This eliminates the duplicate call, and also
improves the readability.