### PR TITLE
Fixed #1028 - Improve logging for local check point conflicted error

### DIFF
--- a/src/main/java/com/couchbase/lite/BlobStore.java
+++ b/src/main/java/com/couchbase/lite/BlobStore.java
@@ -654,7 +654,7 @@ public class BlobStore {
                 magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
                 raf.close();
             } catch (Throwable e) {
-                e.printStackTrace(System.err);
+                Log.e(Log.TAG_BLOB_STORE, "Failed to read from RandomAccessFile", e);
             }
         }
         return magic == GZIPInputStream.GZIP_MAGIC;

--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -18,6 +18,7 @@
 package com.couchbase.lite.internal;
 
 import com.couchbase.lite.Manager;
+import com.couchbase.lite.util.Log;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import java.io.IOException;
@@ -61,7 +62,7 @@ public class Body {
         try {
             props = Manager.getObjectMapper().readValue(json, Map.class);
         } catch (IOException e) {
-            e.printStackTrace();
+            Log.w(Log.TAG_DATABASE, "Failed to parse Json document", e);
         }
         props.putAll(extra);
         this.object = props;

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -852,7 +852,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                         try {
                             processChangeTrackerStopped(changeTracker);
                         } catch (RuntimeException e) {
-                            e.printStackTrace();
+                            Log.e(Log.TAG_CHANGE_TRACKER, "Unknown Error in processChangeTrackerStopped()", e);
                             throw e;
                         }
                     }
@@ -1067,13 +1067,13 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             while (!pendingFutures.isEmpty()) {
                 Future future = pendingFutures.take();
                 try {
-                    Log.d(TAG, "calling future.get() on %s", future);
+                    Log.v(TAG, "calling future.get() on %s", future);
                     future.get();
-                    Log.d(TAG, "done calling future.get() on %s", future);
+                    Log.v(TAG, "done calling future.get() on %s", future);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    Log.e(Log.TAG_SYNC, "InterruptedException in Future.get()", e);
                 } catch (ExecutionException e) {
-                    e.printStackTrace();
+                    Log.e(Log.TAG_SYNC, "ExecutionException in Future.get()", e);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -157,9 +157,9 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                         future.get();
                         Log.d(Log.TAG_SYNC, "done calling future.get() on %s", future);
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        Log.e(Log.TAG_SYNC, "InterruptedException in Future.get()", e);
                     } catch (ExecutionException e) {
-                        e.printStackTrace();
+                        Log.e(Log.TAG_SYNC, "ExecutionException in Future.get()", e);
                     }
                 }
 

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -205,7 +205,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                             Log.d(Log.TAG_SYNC, "firing trigger: %s", trigger);
                             stateMachine.fire(trigger);
                         } catch (Exception e) {
-                            e.printStackTrace();
+                            Log.e(Log.TAG_SYNC, "Unknown Error in stateMachine.fire(trigger)", e);
                             throw new RuntimeException(e);
                         }
                     }
@@ -734,7 +734,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 try {
 
                     if (e != null) {
-                        Log.w(Log.TAG_SYNC, "%s: Unable to save remote checkpoint", e, this);
                         // Failed to save checkpoint:
                         switch (Utils.getStatusFromError(e)) {
                             case Status.NOT_FOUND:
@@ -1111,8 +1110,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 try {
                     changeListener.changed(changeEvent);
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    Log.e(Log.TAG_SYNC, "Exception notifying replication listener: %s", e);
+                    Log.e(Log.TAG_SYNC, "Unknown Error in changeListener.changed(changeEvent)", e);
                 }
             }
         } else {

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -1894,8 +1894,12 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             }
 
         } catch (CouchbaseLiteException e) {
-            e.printStackTrace();
-            Log.e(Log.TAG_ROUTER, "Error updating doc: %s", e, docID);
+            if (e.getCBLStatus() != null && e.getCBLStatus().getCode() == Status.CONFLICT) {
+                // conflict is not critical error for replicators, not print stack trace
+                Log.w(Log.TAG_ROUTER, "Error updating doc: %s", docID);
+            } else {
+                Log.e(Log.TAG_ROUTER, "Error updating doc: %s", e, docID);
+            }
             outStatus.setCode(e.getCBLStatus().getCode());
         }
 


### PR DESCRIPTION
- In case of Conflict, should not print stack trace.
- Remove `Log.w(Log.TAG_SYNC, "%s: Unable to save remote checkpoint", e, this);`. Detailed log was printed in following codes.
- Remove all `Exception.printStackTrace()`. Replace with `Log.e(...)`