### PR TITLE
Fixed #1033 - Requests pending with POST _bulk_docs

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -251,7 +251,9 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Public
     public void compact() throws CouchbaseLiteException {
-        store.compact();
+        synchronized (store) {
+            store.compact();
+        }
         garbageCollectAttachments();
     }
 


### PR DESCRIPTION
##### Problem:
- _bulk_docs: Calling synchronized(db) in transaction wait for db lock with holding SQLite connection
- other request: waiting for SQLConnection with holding db lock.

##### Solution:
Router.java:
- Eliminate all synchronized block from Router as most of database access are protected by Transaction.
- Use runInTransaction for putLocalRevision() which is not inTransaction

Database.java:
- make compact() thread-safe

Concern:
- Database.delete() and Database.close()'s thread-safety. Need to review later.