### PR TITLE
Fixed #1050 - Implement non-problematic flow control logic for push replicator

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -120,8 +120,13 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
             }
             StatusLine status = response.getStatusLine();
             if (status.getStatusCode() >= 300) {
-                Log.e(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
-                        status.getStatusCode(), request, status.getReasonPhrase());
+                // conflict could be happen. So ERROR prints make developer confused.
+                if (status.getStatusCode() == 409)
+                    Log.w(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
+                            status.getStatusCode(), request, status.getReasonPhrase());
+                else
+                    Log.e(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
+                            status.getStatusCode(), request, status.getReasonPhrase());
                 error = new HttpResponseException(status.getStatusCode(),
                         status.getReasonPhrase());
             } else {


### PR DESCRIPTION
- Create new single thread executor per push replicator to take care adding revision ids in inbox. By adding new executor, thread that invokes `changed(Changed)` and thread that invokes `beginReplication()` are not blocked by paused state.

- I will work for difference between `submitRevisions()`'s logic for `changesSince()` and `ChangeListener.changed()` with another ticket. I believe they should be same.

- Update logging level for Conflict error. (this fix is not related with #1050)
