### PR TITLE
Fixed #1047 - Push replication skipped 20 documents

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -251,9 +251,7 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Public
     public void compact() throws CouchbaseLiteException {
-        synchronized (store) {
-            store.compact();
-        }
+        store.compact();
         garbageCollectAttachments();
     }
 
@@ -1365,13 +1363,9 @@ public class Database implements StoreDelegate {
 
     @InterfaceAudience.Private
     public RevisionInternal loadRevisionBody(RevisionInternal rev) throws CouchbaseLiteException {
-        // loadRevisionBody() and getRevisionHistory() are called back by RemoteRequest threads.
-        // That causes non-synchronized access to database.
-        // This issue might not be occured with SQLite because SQLiteDatabase from Android takes
-        // care multi-threads access.
-        synchronized(store) {
-            return store.loadRevisionBody(rev);
-        }
+        // NOTE: loadRevisionBoy() is thread safe. It is read operation to database as storage
+        //       layer is thread-safe, and also not access to instance variables.
+        return store.loadRevisionBody(rev);
     }
 
     /**
@@ -1994,13 +1988,9 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Private
     public List<RevisionInternal> getRevisionHistory(RevisionInternal rev) {
-        // loadRevisionBody() and getRevisionHistory() are called back by RemoteRequest threads.
-        // That causes non-synchronized access to database.
-        // This issue might not be occured with SQLite because SQLiteDatabase from Android takes
-        // care multi-threads access.
-        synchronized(store) {
-            return store.getRevisionHistory(rev);
-        }
+        // NOTE: getRevisionHistory() is thread safe. It is read operation to database as storage
+        //       layer is thread-safe, and also not access to instance variables.
+        return store.getRevisionHistory(rev);
     }
 
     private String getDesignDocFunction(String fnName, String key, List<String> outLanguageList) {

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -631,7 +631,7 @@ public class SQLiteStore implements Store, EncryptableStore {
     public void compact() throws CouchbaseLiteException {
         Log.v(TAG, "Begin database compaction...");
         synchronized (compactLock) {
-            boolean shouldCommit = true;
+            boolean shouldCommit = false;
             beginTransaction();
             try {
                 // Start off by pruning each revision tree's depth:
@@ -650,6 +650,7 @@ public class SQLiteStore implements Store, EncryptableStore {
                     Log.e(TAG, "Error compacting", e);
                     throw new CouchbaseLiteException(Status.INTERNAL_SERVER_ERROR);
                 }
+                shouldCommit = true;
             } finally {
                 endTransaction(shouldCommit);
             }


### PR DESCRIPTION
- Eliminate `synchronized(store)` from Database.java. They are not necessary, also it makes thread wait not right place.
- Make `SQLiteStore.compact()` thread safe. `PRAGMA wal_checkpoint(RESTART)` and `VACUUM` SQL query is suspicious.
- Make `runFilter()` out of SQL query loop to minimize holding SQLite connection in `changesSince()` method. `changesSince()` is frequently called for `/_changes` REST API. And it is bottle neck for listener.