### PR TITLE
Fixed #1061 - NullPointerException in Implementation of Validator

### DIFF
--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -381,12 +381,14 @@ public class Document {
 
         List<SavedRevision> result = new ArrayList<SavedRevision>();
         RevisionList revs = database.getStore().getAllRevisions(documentId, true);
-        for (RevisionInternal rev : revs) {
-            // add it to result, unless we are not supposed to include deleted and it's deleted
-            if (!includeDeleted && rev.isDeleted()) {
-                // don't add it
-            } else {
-                result.add(getRevisionFromRev(rev));
+        if (revs != null) {
+            for (RevisionInternal rev : revs) {
+                // add it to result, unless we are not supposed to include deleted and it's deleted
+                if (!includeDeleted && rev.isDeleted()) {
+                    // don't add it
+                } else {
+                    result.add(getRevisionFromRev(rev));
+                }
             }
         }
         return Collections.unmodifiableList(result);

--- a/src/main/java/com/couchbase/lite/ValidationContextImpl.java
+++ b/src/main/java/com/couchbase/lite/ValidationContextImpl.java
@@ -42,16 +42,22 @@ class ValidationContextImpl implements ValidationContext {
     public List<String> getChangedKeys() {
         if (changedKeys == null) {
             changedKeys = new ArrayList<String>();
-            Map<String, Object> cur = getCurrentRevision().getProperties();
+            Map<String, Object> cur = null;
+            if (getCurrentRevision() != null)
+                cur = getCurrentRevision().getProperties();
             Map<String, Object> nuu = newRev.getProperties();
-            for (String key : cur.keySet()) {
-                if (!cur.get(key).equals(nuu.get(key)) && !key.equals("_rev")) {
-                    changedKeys.add(key);
+            if (null != null) {
+                if (cur != null) {
+                    for (String key : cur.keySet()) {
+                        if (!cur.get(key).equals(nuu.get(key)) && !key.equals("_rev")) {
+                            changedKeys.add(key);
+                        }
+                    }
                 }
-            }
-            for (String key : nuu.keySet()) {
-                if (cur.get(key) == null && !key.equals("_rev") && !key.equals("_id")) {
-                    changedKeys.add(key);
+                for (String key : nuu.keySet()) {
+                    if ((cur == null || cur.get(key) == null) && !key.equals("_rev") && !key.equals("_id")) {
+                        changedKeys.add(key);
+                    }
                 }
             }
         }

--- a/src/main/java/com/couchbase/lite/ValidationContextImpl.java
+++ b/src/main/java/com/couchbase/lite/ValidationContextImpl.java
@@ -46,18 +46,16 @@ class ValidationContextImpl implements ValidationContext {
             if (getCurrentRevision() != null)
                 cur = getCurrentRevision().getProperties();
             Map<String, Object> nuu = newRev.getProperties();
-            if (null != null) {
+            if (nuu != null) {
                 if (cur != null) {
                     for (String key : cur.keySet()) {
-                        if (!cur.get(key).equals(nuu.get(key)) && !key.equals("_rev")) {
+                        if (cur.get(key) != null && !cur.get(key).equals(nuu.get(key)) && !key.equals("_rev"))
                             changedKeys.add(key);
-                        }
                     }
                 }
                 for (String key : nuu.keySet()) {
-                    if ((cur == null || cur.get(key) == null) && !key.equals("_rev") && !key.equals("_id")) {
+                    if ((cur == null || cur.get(key) == null) && !key.equals("_rev") && !key.equals("_id"))
                         changedKeys.add(key);
-                    }
                 }
             }
         }


### PR DESCRIPTION
In case of creating new document or deleting the document, Validator could cause NPE if access getKeyChanges() or isDeleted(). So added null check.