### PR TITLE
Fixed #1069 - Deleting database and stopping replications at the same…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -823,14 +823,6 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      * @exclude
      */
     @InterfaceAudience.Private
-    public void databaseClosing() {
-        replicationInternal.databaseClosing();
-    }
-
-    /**
-     * @exclude
-     */
-    @InterfaceAudience.Private
     public String getSessionID() {
         return replicationInternal.getSessionID();
     }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -291,10 +291,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         checkSession();
     }
 
-    public void databaseClosing() {
-        triggerStopGraceful();
-    }
-
     /**
      * Close all resources associated with this replicator.
      */


### PR DESCRIPTION
… time

- When calling `Database.delete() -> Database.close()`, some of replicators are stopping because of `/_replicate` with `cancel=true` requests. It seems some replicators stops before adding `Replication.ChangeLister`, then `latch.countDown()` for these replicators are never called. Then it makes following codes to wait 60 sec per missing STOPPED notification. In case of customer scenario, customer creates 10 replicators, worst case scenario is 10min waiting.
To avoid above, before calling `latch.await()`, check if replicator is still active. If yes, call `latch.await()`, otherwise, none.

Changes that are not related with this ticket:
- `databaseClosing()` method is same with `stop()` method. Eliminated it.
-  `readOnly` variable in Database, is never used. Eliminated it.