### PR TITLE
Fixed #1074 - Enhance logging information for replicator and set thre…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -79,6 +79,7 @@ public class ChangeTracker implements Runnable {
     protected ChangeTrackerBackoff backoff;
     private long startTime = 0;
 
+    private String str = null;
 
     public enum ChangeTrackerMode {
         OneShot,
@@ -652,5 +653,14 @@ public class ChangeTracker implements Runnable {
                 } catch (InterruptedException e) { }
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        if (str == null) {
+            String remoteURL = databaseURL.toExternalForm().replaceAll("://.*:.*@", "://---:---@");
+            str = String.format("ChangeTracker{%s, %s}", remoteURL, mode);
+        }
+        return str;
     }
 }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -1044,7 +1044,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
             String type = parentReplication.isPull() ? "pull" : "push";
             String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
-            str = String.format("PusherInternal{%s, %s, %s}",
+            str = String.format("PullerInternal{%s, %s, %s}",
                     maskedRemote, type, replicationIdentifier);
         }
         return str;

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -77,6 +77,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     protected int httpConnectionCount;
     protected Batcher<RevisionInternal> downloadsToInsert;
 
+    private String str = null;
+
     public PullerInternal(Database db,
                           URL remote,
                           HttpClientFactory clientFactory,
@@ -908,12 +910,13 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     }
 
     private void waitForPendingFuturesWithNewThread() {
+        String threadName = String.format("Thread.waitForPendingFutures[%s]", toString());
         new Thread(new Runnable() {
             @Override
             public void run() {
                 waitForPendingFutures();
             }
-        }).start();
+        }, threadName).start();
     }
 
     @Override
@@ -974,6 +977,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         // this has to be on a different thread than the replicator thread, or else it's a deadlock
         // because it might be waiting for jobs that have been scheduled, and not
         // yet executed (and which will never execute because this will block processing).
+        String threadName = String.format("Thread.waitForAllTasksCompleted[%s]", toString());
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -988,7 +992,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     Log.d(TAG, "PullerInternal stop.run() finished");
                 }
             }
-        }).start();
+        }, threadName).start();
     }
 
     protected void waitForAllTasksCompleted() {
@@ -1031,5 +1035,18 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     protected void pauseOrResume() {
         int pending = batcher.count() + pendingSequences.count();
         changeTracker.setPaused(pending >= MAX_PENDING_DOCS);
+    }
+
+    @Override
+    public String toString() {
+        if (str == null) {
+            String maskedRemote = remote.toExternalForm();
+            maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
+            String type = parentReplication.isPull() ? "pull" : "push";
+            String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
+            str = String.format("PusherInternal{%s, %s, %s}",
+                    maskedRemote, type, replicationIdentifier);
+        }
+        return str;
     }
 }

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -54,7 +54,6 @@ public class RemoteRequest implements Runnable {
     protected RemoteRequestCompletionBlock onPreCompletion;
     protected RemoteRequestCompletionBlock onCompletion;
     protected RemoteRequestCompletionBlock onPostCompletion;
-    private Database db;
     protected HttpUriRequest request;
 
     protected Map<String, Object> requestHeaders;
@@ -64,6 +63,8 @@ public class RemoteRequest implements Runnable {
 
     // if true, send compressed (gzip) request
     private boolean compressedRequest = false;
+
+    private String str = null;
 
     public RemoteRequest(ScheduledExecutorService workExecutor,
                          HttpClientFactory clientFactory, String method, URL url,
@@ -75,10 +76,8 @@ public class RemoteRequest implements Runnable {
         this.onCompletion = onCompletion;
         this.workExecutor = workExecutor;
         this.requestHeaders = requestHeaders;
-        this.db = db;
         this.request = createConcreteRequest();
         Log.v(Log.TAG_SYNC, "%s: RemoteRequest created, url: %s", this, url);
-
     }
 
     @Override
@@ -369,5 +368,14 @@ public class RemoteRequest implements Runnable {
         ByteArrayEntity entity = new ByteArrayEntity(bodyBytes);
         entity.setContentType("application/json");
         return entity;
+    }
+
+    @Override
+    public String toString() {
+        if (str == null) {
+            String remoteURL = url.toExternalForm().replaceAll("://.*:.*@", "://---:---@");
+            str = String.format("RemoteRequest{%s, %s}", method, remoteURL);
+        }
+        return str;
     }
 }


### PR DESCRIPTION
…ad name to replicator related threads.

- Set thread name to all replicator related thread.
- Add `toString()` for replicator related classes to track log information easily.