### PR TITLE
Fixed #1068 and #1030 - Pull replication skipped documents / Requests…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -95,7 +95,7 @@ public class ChangeTracker implements Runnable {
         this.lastSequenceID = lastSequenceID;
         this.client = client;
         this.requestHeaders = new HashMap<String, Object>();
-        this.heartBeatSeconds = 300;
+        this.heartBeatSeconds = Replication.DEFAULT_HEARTBEAT;
         this.limit = 50;
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -52,7 +52,9 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
      */
     public static final String REPLICATOR_DATABASE_NAME = "_replicator";
 
-    public static final long DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN = 60; // 60 sec
+    public static long DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN = 60; // 60 sec
+
+    public static int DEFAULT_HEARTBEAT = 300; // 5min (300 sec)
 
     /**
      * Options for what metadata to include in document bodies

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -79,8 +79,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
     private static int lastSessionID = 0;
 
-    public final static int MAX_RETRIES = 10;  // total number of attempts = 11 (1 initial + MAX_RETRIES)
-    public final static int RETRY_DELAY_SECONDS = 20; // #define kRetryDelay 60.0 in CBL_Replicator.m
+    public static int MAX_RETRIES = 10;  // total number of attempts = 11 (1 initial + MAX_RETRIES)
+    public static int RETRY_DELAY_SECONDS = 20; // #define kRetryDelay 60.0 in CBL_Replicator.m
 
     protected Replication parentReplication;
     protected Database db;

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -79,8 +79,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
     private static int lastSessionID = 0;
 
-    public static int MAX_RETRIES = 10;  // total number of attempts = 11 (1 initial + MAX_RETRIES)
-    public static int RETRY_DELAY_SECONDS = 60; // #define kRetryDelay 60.0 in CBL_Replicator.m
+    public final static int MAX_RETRIES = 10;  // total number of attempts = 11 (1 initial + MAX_RETRIES)
+    public final static int RETRY_DELAY_SECONDS = 20; // #define kRetryDelay 60.0 in CBL_Replicator.m
 
     protected Replication parentReplication;
     protected Database db;
@@ -1420,7 +1420,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
      * helper function to schedule retry future. no in iOS code.
      */
     private void scheduleRetryFuture() {
-        long delay = RETRY_DELAY_SECONDS * (long) Math.pow((double) 2, (double) Math.min(retryCount, MAX_RETRIES));
+        long delay = (long) (RETRY_DELAY_SECONDS * Math.pow(1.5, (double) retryCount));
         Log.v(Log.TAG_SYNC, "%s: Failed to xfer; will retry in %d sec",
                 this, delay);
         this.retryFuture = workExecutor.schedule(new Runnable() {
@@ -1444,27 +1444,27 @@ abstract class ReplicationInternal implements BlockingQueueListener {
      * Retry replication if previous attempt ends with error
      */
     protected void retryReplicationIfError() {
-        // Make sure if state is IDLE, this method should be called when state becomes IDLE
-        if (!stateMachine.getState().equals(ReplicationState.IDLE)) {
-            return;
-        }
+        Log.d(TAG, "retryReplicationIfError() retryCount=" + retryCount +
+                ", state=" + stateMachine.getState() +
+                ", error=" + this.error +
+                ", isContinuous()=" + isContinuous() +
+                ", isTransientError()=" + Utils.isTransientError(this.error));
 
-        // IDLE_OK
-        if (this.error == null) {
+        // Make sure if state is IDLE, this method should be called when state becomes IDLE
+        if (!stateMachine.getState().equals(ReplicationState.IDLE))
+            return;
+
+        if (this.error == null)
+            // IDLE_OK
             retryCount = 0;
-        }
-        // IDLE_ERROR
         else {
-            // not retry infinite times
-            if (retryCount < MAX_RETRIES) {
-                // mode should be continuous
-                if (isContinuous()) {
-                    // 12/16/2014 - only retry if error is transient error 50x http error
-                    // It may need to retry for any kind of errors
-                    if (Utils.isTransientError(this.error)) {
-                        cancelRetryFuture();
-                        scheduleRetryFuture();
-                    }
+            // IDLE_ERROR
+            if (isContinuous()) {
+                // 12/16/2014 - only retry if error is transient error 50x http error
+                // It may need to retry for any kind of errors
+                if (Utils.isTransientError(this.error)) {
+                    cancelRetryFuture();
+                    scheduleRetryFuture();
                 }
             }
         }

--- a/src/main/java/com/couchbase/lite/router/BufferInputStream.java
+++ b/src/main/java/com/couchbase/lite/router/BufferInputStream.java
@@ -14,38 +14,38 @@ public class BufferInputStream extends InputStream {
     public int read() throws IOException {
         ByteBuffer buffer = os.getBuffer();
         synchronized (buffer) {
-            while(buffer.isEmpty()) {
-                if(os.isClosed()) {
+            while (buffer.isEmpty()) {
+                if (os.isClosed()) {
                     return -1;
                 }
                 try {
-                    buffer.wait();
+                    buffer.wait(1000); // 1sec
                 } catch (InterruptedException e) {
                     // ignore
                 }
             }
-            return (int)buffer.pop();
+            return (int) buffer.pop();
         }
     }
 
     public int read(byte[] bytes, int offset, int length) throws IOException {
-        if(bytes == null) {
+        if (bytes == null) {
             throw new NullPointerException();
         }
-        if(offset + length > bytes.length) {
+        if (offset + length > bytes.length) {
             throw new ArrayIndexOutOfBoundsException();
         }
-        if(offset < 0) {
+        if (offset < 0) {
             throw new IllegalArgumentException("offset can not be negative");
         }
         ByteBuffer buffer = os.getBuffer();
         synchronized (buffer) {
-            while(buffer.isEmpty()) {
-                if(os.isClosed()) {
+            while (buffer.isEmpty()) {
+                if (os.isClosed()) {
                     return -1;
                 }
                 try {
-                    buffer.wait();
+                    buffer.wait(1000); // 1sec
                 } catch (InterruptedException e) {
                     // ignore
                 }

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -54,6 +54,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -61,6 +63,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class Router implements Database.ChangeListener, Database.DatabaseListener {
+
+    private final static long MIN_HEARTBEAT = 5000; // 5 second
 
     /**
      * Options for what metadata to include in document bodies
@@ -89,6 +93,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     private boolean longpoll = false;
     private boolean waiting = false;
     private URL source = null;
+    private Timer timer = null; // timer for heartbeat
 
     private final Object databaseChangesLongpollLock = new Object();
 
@@ -99,6 +104,12 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     public Router(Manager manager, URLConnection connection) {
         this.manager = manager;
         this.connection = connection;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        stop();
+        super.finalize();
     }
 
     public void setCallbackBlock(RouterCallbackBlock callbackBlock) {
@@ -574,6 +585,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     }
 
     public void stop() {
+        stopHeartbeat();
         callbackBlock = null;
         if (db != null) {
             db.removeChangeListener(this);
@@ -1600,7 +1612,25 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                 }
             }
             db.addChangeListener(this);
+
+            // heartbeat
+            String heartbeatParam = getQuery("heartbeat");
+            if (heartbeatParam != null) {
+                long heartbeat = 0;
+                try {
+                    heartbeat = (long) Double.parseDouble(heartbeatParam);
+                } catch (Exception e) {
+                    return new Status(Status.BAD_REQUEST);
+                }
+                if (heartbeat <= 0)
+                    return new Status(Status.BAD_REQUEST);
+                else if (heartbeat < MIN_HEARTBEAT)
+                    heartbeat = MIN_HEARTBEAT;
+                startHeartbeat(heartbeat);
+            }
+
             // Don't close connection; more data to come
+
             return new Status(0);
         } else {
             if (options.isIncludeConflicts()) {
@@ -1609,6 +1639,40 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                 connection.setResponseBody(new Body(responseBodyForChanges(changes, since)));
             }
             return new Status(Status.OK);
+        }
+    }
+
+    private void startHeartbeat(long interval) {
+        if (interval <= 0)
+            return;
+
+        stopHeartbeat();
+        timer = new Timer();
+        timer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                synchronized (databaseChangesLongpollLock) {
+                    OutputStream os = connection.getResponseOutputStream();
+                    if (os != null) {
+                        try {
+                            os.write("\r\n".getBytes());
+                            os.flush();
+                        } catch (IOException e) {
+                            Log.w(Log.TAG_ROUTER, "IOException writing to internal streams: " + e.getMessage());
+                        } finally {
+                            // no close outputstream, OutputStream might be re-used
+                        }
+                    }
+                }
+            }
+        }, interval, interval);
+    }
+
+    private void stopHeartbeat() {
+        if (timer != null) {
+            timer.cancel();
+            timer.purge();
+            timer = null;
         }
     }
 

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -74,13 +74,16 @@ public class Utils {
         } else if (throwable instanceof HttpResponseException) {
             HttpResponseException e = (HttpResponseException) throwable;
             return isTransientError(e.getStatusCode());
-        }
-        // connection and socket timeouts => transient error
-        else if (throwable instanceof java.net.SocketTimeoutException){
+        } else if (throwable instanceof java.net.SocketTimeoutException)
+            // connection and socket timeouts => transient error
             return true;
-        } else {
+        else if (throwable instanceof org.apache.http.conn.ConnectTimeoutException)
+            return true;
+        else if (throwable instanceof java.net.ConnectException)
+            // connection issue => transient error
+            return true;
+        else
             return false;
-        }
     }
 
     public static boolean isTransientError(StatusLine status) {


### PR DESCRIPTION
… to Listener in pending state

- Fixed isTransientError() method (Utils)
- Fixed retry logic. No max retry count. (ReplicationInternal)
- Implemented heartbeat for /_change REST API (Router)
- Set 1sec timeout for `Object.wait()` in BufferInputStream to avoid wait forever.