### PR TITLE
Fixed 1093 - Listener does not accept new connection

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -131,6 +131,8 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                                 status.getStatusCode(), request, status.getReasonPhrase());
                     error = new HttpResponseException(status.getStatusCode(),
                             status.getReasonPhrase());
+                    respondWithResult(fullBody, error, response);
+                    return;
                 } finally {
                     HttpEntity entity = response.getEntity();
                     if (entity != null) {
@@ -164,7 +166,6 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                                         _topReader.appendData(buffer, 0, nBytesRead);
                                     }
                                     _topReader.finished();
-                                    respondWithResult(fullBody, error, response);
                                 }
                                 // non-multipart
                                 else {
@@ -172,8 +173,9 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                                             contentTypeHeader.getValue());
                                     fullBody = Manager.getObjectMapper().readValue(
                                             inputStream, Object.class);
-                                    respondWithResult(fullBody, error, response);
                                 }
+                                respondWithResult(fullBody, error, response);
+                                return;
                             }
                         } finally {
                             try {
@@ -193,16 +195,14 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
                     }
                 }
             }
-        } catch (IOException e) {
-            Log.e(Log.TAG_REMOTE_REQUEST, "io exception", e);
-            error = e;
         } catch (Exception e) {
             Log.e(Log.TAG_REMOTE_REQUEST, "%s: executeRequest() Exception: ", e, this);
             error = e;
         } finally {
             Log.v(TAG, "%s: BulkDownloader finally block.  url: %s", this, url);
         }
-        Log.v(TAG, "%s: BulkDownloader calling respondWithResult.  url: %s, error: %s", this, url, error);
+
+        // error scenario
         respondWithResult(fullBody, error, response);
     }
 

--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -121,15 +121,25 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
             }
             StatusLine status = response.getStatusLine();
             if (status.getStatusCode() >= 300) {
-                // conflict could be happen. So ERROR prints make developer confused.
-                if (status.getStatusCode() == 409)
-                    Log.w(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
-                            status.getStatusCode(), request, status.getReasonPhrase());
-                else
-                    Log.e(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
-                            status.getStatusCode(), request, status.getReasonPhrase());
-                error = new HttpResponseException(status.getStatusCode(),
-                        status.getReasonPhrase());
+                try {
+                    // conflict could be happen. So ERROR prints make developer confused.
+                    if (status.getStatusCode() == 409)
+                        Log.w(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
+                                status.getStatusCode(), request, status.getReasonPhrase());
+                    else
+                        Log.e(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s",
+                                status.getStatusCode(), request, status.getReasonPhrase());
+                    error = new HttpResponseException(status.getStatusCode(),
+                            status.getReasonPhrase());
+                } finally {
+                    HttpEntity entity = response.getEntity();
+                    if (entity != null) {
+                        try {
+                            entity.consumeContent();
+                        } catch (IOException e) {
+                        }
+                    }
+                }
             } else {
                 HttpEntity entity = response.getEntity();
                 try {

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -336,6 +336,13 @@ public class ChangeTracker implements Runnable {
                                     mode != ChangeTrackerMode.LongPoll)) {
                         Log.e(Log.TAG_CHANGE_TRACKER, "%s: Change tracker got error %d", this, status.getStatusCode());
                         this.error = new HttpResponseException(status.getStatusCode(), status.getReasonPhrase());
+                        HttpEntity entity = response.getEntity();
+                        if (entity != null) {
+                            try {
+                                entity.consumeContent();
+                            } catch (IOException e) {
+                            }
+                        }
                         break;
                     }
 

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTrackerClient.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTrackerClient.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public interface ChangeTrackerClient {
     HttpClient getHttpClient();
 
-    void changeTrackerReceivedChange(Map<String,Object> change);
+    void changeTrackerReceivedChange(Map<String, Object> change);
 
     void changeTrackerStopped(ChangeTracker tracker);
 

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -770,10 +770,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     @Override
     public HttpClient getHttpClient() {
-
-        HttpClient httpClient = this.clientFactory.getHttpClient();
-
-        return httpClient;
+        return clientFactory.getHttpClient();
     }
 
     @Override

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -1656,6 +1656,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                     OutputStream os = connection.getResponseOutputStream();
                     if (os != null) {
                         try {
+                            Log.v(Log.TAG_ROUTER, "[%s] Sent heart beat!", this);
                             os.write("\r\n".getBytes());
                             os.flush();
                         } catch (IOException e) {

--- a/src/main/java/com/couchbase/lite/support/HttpClientFactory.java
+++ b/src/main/java/com/couchbase/lite/support/HttpClientFactory.java
@@ -7,8 +7,11 @@ import org.apache.http.cookie.Cookie;
 import java.util.List;
 
 public interface HttpClientFactory {
-	HttpClient getHttpClient();
-    public void addCookies(List<Cookie> cookies);
-    public void deleteCookie(String name);
-    public CookieStore getCookieStore();
+    HttpClient getHttpClient();
+
+    void addCookies(List<Cookie> cookies);
+
+    void deleteCookie(String name);
+
+    CookieStore getCookieStore();
 }

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
@@ -81,6 +81,7 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
                     error = new HttpResponseException(status.getStatusCode(),
                             status.getReasonPhrase());
                     respondWithResult(fullBody, error, response);
+                    return;
                 } finally {
                     HttpEntity entity = response.getEntity();
                     if (entity != null) {
@@ -113,13 +114,13 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
                                     }
                                     reader.finish();
                                     fullBody = reader.getDocumentProperties();
-                                    respondWithResult(fullBody, error, response);
                                 }
                                 // non-multipart
                                 else {
                                     fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
-                                    respondWithResult(fullBody, error, response);
                                 }
+                                respondWithResult(fullBody, error, response);
+                                return;
                             }
                         }
                         finally {
@@ -141,14 +142,14 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
                     }
                 }
             }
-        } catch (IOException e) {
-            Log.e(Log.TAG_REMOTE_REQUEST, "%s: io exception", e, this);
-            respondWithResult(fullBody, e, response);
         } catch (Exception e) {
             Log.e(Log.TAG_REMOTE_REQUEST, "%s: executeRequest() Exception: ", e, this);
             respondWithResult(fullBody, e, response);
         } finally {
-            Log.d(Log.TAG_REMOTE_REQUEST, "%s: executeRequest() finally", this);
+            Log.v(Log.TAG_REMOTE_REQUEST, "%s: executeRequest() finally", this);
         }
+
+        // error scenario
+        respondWithResult(fullBody, error, response);
     }
 }

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
@@ -76,10 +76,20 @@ public class RemoteMultipartDownloaderRequest extends RemoteRequest {
 
             StatusLine status = response.getStatusLine();
             if (status.getStatusCode() >= 300) {
-                Log.e(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s", status.getStatusCode(), request, status.getReasonPhrase());
-                error = new HttpResponseException(status.getStatusCode(),
-                        status.getReasonPhrase());
-                respondWithResult(fullBody, error, response);
+                try {
+                    Log.e(Log.TAG_REMOTE_REQUEST, "Got error status: %d for %s.  Reason: %s", status.getStatusCode(), request, status.getReasonPhrase());
+                    error = new HttpResponseException(status.getStatusCode(),
+                            status.getReasonPhrase());
+                    respondWithResult(fullBody, error, response);
+                } finally {
+                    HttpEntity entity = response.getEntity();
+                    if (entity != null) {
+                        try {
+                            entity.consumeContent();
+                        } catch (IOException e) {
+                        }
+                    }
+                }
             } else {
                 HttpEntity entity = response.getEntity();
                 try {

--- a/src/main/java/com/couchbase/lite/support/RemoteRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequest.java
@@ -82,12 +82,9 @@ public class RemoteRequest implements Runnable {
 
     @Override
     public void run() {
-
+        Log.v(Log.TAG_SYNC, "%s: RemoteRequest run() called, url: %s", this, url);
+        HttpClient httpClient = clientFactory.getHttpClient();
         try {
-            Log.v(Log.TAG_SYNC, "%s: RemoteRequest run() called, url: %s", this, url);
-
-            HttpClient httpClient = clientFactory.getHttpClient();
-
             preemptivelySetAuthCredentials(httpClient);
 
             request.addHeader("Accept", "multipart/related, application/json");
@@ -100,13 +97,18 @@ public class RemoteRequest implements Runnable {
 
             executeRequest(httpClient, request);
 
+            // shutdown connection manager (close all connections)
+            httpClient.getConnectionManager().shutdown();
+
             Log.v(Log.TAG_SYNC, "%s: RemoteRequest run() finished, url: %s", this, url);
 
         } catch (Throwable e) {
             Log.e(Log.TAG_SYNC, "RemoteRequest.run() exception: %s", e);
+        } finally {
+            // shutdown connection manager (close all connections)
+            if (httpClient != null && httpClient.getConnectionManager() != null)
+                httpClient.getConnectionManager().shutdown();
         }
-
-
     }
 
     public void abort() {
@@ -158,16 +160,10 @@ public class RemoteRequest implements Runnable {
     }
 
     protected void executeRequest(HttpClient httpClient, HttpUriRequest requestParam) {
-
         Object fullBody = null;
         Throwable error = null;
         HttpResponse response = null;
-
         try {
-            fullBody = null;
-            error = null;
-            response = null;
-
             Log.v(Log.TAG_SYNC, "%s: RemoteRequest calling httpClient.execute, url: %s", this, url);
 
             if (requestParam.isAborted()) {
@@ -202,28 +198,32 @@ public class RemoteRequest implements Runnable {
                 respondWithResult(fullBody, error, response);
                 return;
             } else {
-                HttpEntity entity = null;
-                InputStream inputStream = null;
-                GZIPInputStream gzipStream = null;
+                HttpEntity entity = response.getEntity();
                 try {
-                    entity = response.getEntity();
                     if (entity != null) {
-                        inputStream = entity.getContent();
-                        // decompress if contentEncoding is gzip
-                        if (Utils.isGzip(entity)) {
-                            gzipStream = new GZIPInputStream(inputStream);
-                            fullBody = Manager.getObjectMapper().readValue(gzipStream, Object.class);
-                        } else {
+                        InputStream inputStream = entity.getContent();
+                        try {
+                            // decompress if contentEncoding is gzip
+                            if (Utils.isGzip(entity))
+                                inputStream = new GZIPInputStream(inputStream);
+
                             fullBody = Manager.getObjectMapper().readValue(inputStream, Object.class);
+                        } finally {
+                            try {
+                                if (inputStream != null) {
+                                    inputStream.close();
+                                }
+                            } catch (IOException e) {
+                            }
                         }
                     }
-                }finally {
-                    try { if (gzipStream != null) { gzipStream.close(); } } catch (IOException e) { }
-                    gzipStream = null;
-                    try { if (inputStream != null) { inputStream.close(); } } catch (IOException e) { }
-                    inputStream = null;
-                    if(entity != null){try{ entity.consumeContent(); }catch (IOException e){}}
-                    entity = null;
+                } finally {
+                    if (entity != null) {
+                        try {
+                            entity.consumeContent();
+                        } catch (IOException e) {
+                        }
+                    }
                 }
             }
         } catch (IOException e) {
@@ -245,7 +245,6 @@ public class RemoteRequest implements Runnable {
 
         Log.v(Log.TAG_SYNC, "%s: RemoteRequest calling respondWithResult.  url: %s, error: %s", this, url, error);
         respondWithResult(fullBody, error, response);
-
     }
 
     protected void preemptivelySetAuthCredentials(HttpClient httpClient) {


### PR DESCRIPTION
- Make sure `InputStream.close()` is called whenever InputStream was created from `HttpEntity`
- Make sure `HttpEntity.consumeContent()` is called whenever `HttpClient.execute()` is called successfully. (Both HTTP OK and ERROR)
- Make sure `ConnectionManager.shutdown()` is called after HttpClient is created and is used.

Note: It looks many code changes. But they are indenting update.