### PR TITLE
Fixed #1104 - Push replicator stops unexpectedly with CBL Listener

### DIFF
--- a/src/main/java/com/couchbase/lite/Status.java
+++ b/src/main/java/com/couchbase/lite/Status.java
@@ -39,6 +39,7 @@ public class Status {
     public static final int NOT_FOUND = 404;
     public static final int METHOD_NOT_ALLOWED = 405;
     public static final int NOT_ACCEPTABLE = 406;
+    public static final int REQUEST_TIMEOUT = 408;
     public static final int CONFLICT = 409;
     public static final int GONE = 410;
     public static final int DUPLICATE = 412;                // Formally known as "Precondition Failed" (PRECONDITION_FAILED)

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -289,7 +289,7 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
 
         }
 
-        Log.d(Log.TAG_SYNC, "%s: return false");
+        Log.d(Log.TAG_SYNC, "%s: return false", this);
         return false;
 
     }

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -60,7 +60,8 @@ public class Utils {
         // 406 - in Test cases, server return 406 because of CouchDB API
         //       http://docs.couchdb.org/en/latest/api/database/bulk-api.html
         //       GET /{db}/_all_docs or POST /{db}/_all_docs
-        return (code >= 400 && code <= 405) || (code >= 407 && code <= 499);
+        // 408 - Listener might encounter SocketTimeout under weak network connectivity
+        return (code >= 400 && code <= 405) || (code == 407) || (code >= 409 && code <= 499);
     }
 
     /**
@@ -105,7 +106,8 @@ public class Utils {
     }
 
     public static boolean isTransientError(int statusCode) {
-        if (statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504) {
+        if (statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504 ||
+                statusCode == Status.REQUEST_TIMEOUT) {
             return true;
         }
         return false;


### PR DESCRIPTION
In case InputStream.read() files with SocketTimetoutException during JSON parsing by Jackson, it returned as BAD REQUEST or BAD JSON. Replicator handled these response as permanent error.
Solution, we returned 408 (Request Timeout) for above scenario, then Replicator handled 408 as transient error.