### PR TITLE
Fixed #1106 - multiple ChangeTracker.

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -92,15 +92,19 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
      * Actual work of starting the replication process.
      */
     protected void beginReplicating() {
-        Log.d(TAG, "startReplicating()");
-
-        initPendingSequences();
-
-        initDownloadsToInsert();
-
-        startChangeTracker();
-
-        // start replicator ..
+        Log.v(TAG, "submit startReplicating()");
+        workExecutor.submit(new Runnable() {
+            @Override
+            public void run() {
+                if(isRunning()) {
+                    Log.v(TAG, "start startReplicating()");
+                    initPendingSequences();
+                    initDownloadsToInsert();
+                    startChangeTracker();
+                }
+                // start replicator ...
+            }
+        });
     }
 
     private void initDownloadsToInsert() {

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1199,6 +1199,10 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
         // ignored transitions
         stateMachine.configure(ReplicationState.RUNNING).ignore(ReplicationTrigger.START);
+        stateMachine.configure(ReplicationState.IDLE).ignore(ReplicationTrigger.START);
+        stateMachine.configure(ReplicationState.OFFLINE).ignore(ReplicationTrigger.START);
+        stateMachine.configure(ReplicationState.STOPPING).ignore(ReplicationTrigger.START);
+        stateMachine.configure(ReplicationState.STOPPED).ignore(ReplicationTrigger.START);
         stateMachine.configure(ReplicationState.STOPPING).ignore(ReplicationTrigger.STOP_GRACEFUL);
         stateMachine.configure(ReplicationState.STOPPED).ignore(ReplicationTrigger.STOP_GRACEFUL);
         stateMachine.configure(ReplicationState.STOPPED).ignore(ReplicationTrigger.STOP_IMMEDIATE);


### PR DESCRIPTION
- If change tracker is middle of waiting response from server through Jackson JSON parser, ChangeTracker can not stop. Needs to close InputStream.
- beginReplicating is not thread-safe, it potentially caused multiple change tracker.
- StateMachine was not completely defined.