### PR TITLE
Fixed android 790 - ClassCastException when upgrading from 1.1 to 1.2

### DIFF
--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -1632,7 +1632,9 @@ public class SQLiteStore implements Store, EncryptableStore {
                         json = RevisionUtils.asCanonicalJSON(inRev);
                         if (json == null)
                             throw new CouchbaseLiteException(Status.BAD_JSON);
-                        docType = (String) rev.getObject("type");
+                        Object obj = rev.getObject("type");
+                        if (obj != null && obj instanceof String)
+                            docType = (String) obj;
                         current = true;
                     } else {
                         // It's an intermediate parent, so insert a stub:


### PR DESCRIPTION
- Should set docType if value of `type` field is String