### PR TITLE
Fixed #1112 - Multiple ChangeTrackers are started (Scenario 2)

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -129,6 +129,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     }
 
     protected void startChangeTracker() {
+        // make sure not start new changeTracker if pull replicator is not running or idle
+        if (!(stateMachine.isInState(ReplicationState.RUNNING) ||
+                stateMachine.isInState(ReplicationState.IDLE)))
+            return;
 
         ChangeTracker.ChangeTrackerMode changeTrackerMode;
 


### PR DESCRIPTION
- make sure not start new changeTracker if pull replicator is not running or idle