### PR TITLE
Fixed #1114 - Thread stuck in `RemoteRequestRetry.get`

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -918,7 +918,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     }
 
     private void waitForPendingFuturesWithNewThread() {
-        String threadName = String.format("Thread.waitForPendingFutures[%s]", toString());
+        String threadName = String.format("Thread-waitForPendingFutures[%s]", toString());
         new Thread(new Runnable() {
             @Override
             public void run() {

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -158,7 +158,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
         // this has to be on a different thread than the replicator thread, or else it's a deadlock
         // because it might be waiting for jobs that have been scheduled, and not
         // yet executed (and which will never execute because this will block processing).
-        String threadName = String.format("Thread.waitForPendingFutures[%s]", toString());
+        String threadName = String.format("Thread-waitForPendingFutures[%s]", toString());
         new Thread(new Runnable() {
             @Override
             public void run() {

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -124,7 +124,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
     // for waitingPendingFutures
     protected boolean waitingForPendingFutures = false;
-    protected Object lockWaitForPendingFutures = new Object();
+    final protected Object lockWaitForPendingFutures = new Object();
 
     /**
      * Constructor
@@ -1706,7 +1706,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                     fireTrigger(ReplicationTrigger.RESUME);
 
                 // run waitForPendingFutures.
-                String threadName = String.format("Thread.waitForPendingFutures[%s]", toString());
+                String threadName = String.format("Thread-waitForPendingFutures[%s]", toString());
                 new Thread(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
- In case REST API fails with permanent error or Replicator is shut down, Future is not put into pendingFuture. So waitForPendingFutures waits for empty BlockingQueue. As solution, we set timeout to take Future from pendingFutures, and check if re-wait-able by completed flag.