### PR TITLE
Fixed #1116 - Multiple ChangeTrackers are started (Scenario 3)

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -520,12 +520,12 @@ public class ChangeTracker implements Runnable {
 
     public boolean start() {
         Log.d(Log.TAG_CHANGE_TRACKER, "%s: Changed tracker asked to start", this);
+        running = true;
         this.error = null;
         String maskedRemoteWithoutCredentials = databaseURL.toExternalForm();
         maskedRemoteWithoutCredentials = maskedRemoteWithoutCredentials.replaceAll("://.*:.*@", "://---:---@");
         thread = new Thread(this, "ChangeTracker-" + maskedRemoteWithoutCredentials);
         thread.start();
-        running = true;
         return true;
     }
 


### PR DESCRIPTION
- By setting running true after `Thread.start()`, running variable could be false when method check it.