### PR TITLE
FIXED #1131 - UnitTest, ReplicatoinTest.testStartReplicationClosedDb(…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -1049,10 +1049,16 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     @Override
     public String toString() {
         if (str == null) {
-            String maskedRemote = remote.toExternalForm();
+            String maskedRemote = "unknown";
+            if (remote != null)
+                remote.toExternalForm();
             maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
-            String type = parentReplication.isPull() ? "pull" : "push";
+            String type = "unknown";
+            if (parentReplication != null)
+                type = parentReplication.isPull() ? "pull" : "push";
             String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
+            if (replicationIdentifier == null)
+                replicationIdentifier = "unknown";
             str = String.format("PullerInternal{%s, %s, %s}",
                     maskedRemote, type, replicationIdentifier);
         }

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -85,7 +85,8 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
      * @exclude
      */
     @InterfaceAudience.Private
-    public PusherInternal(Database db, URL remote,
+    public PusherInternal(Database db,
+                          URL remote,
                           HttpClientFactory clientFactory,
                           ScheduledExecutorService workExecutor,
                           Replication.Lifecycle lifecycle,
@@ -873,10 +874,16 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
     @Override
     public String toString() {
         if (str == null) {
-            String maskedRemote = remote.toExternalForm();
+            String maskedRemote = "unknown";
+            if (remote != null)
+                maskedRemote = remote.toExternalForm();
             maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
-            String type = parentReplication.isPull() ? "pull" : "push";
+            String type = "unknown";
+            if (parentReplication != null)
+                type = parentReplication.isPull() ? "pull" : "push";
             String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
+            if (replicationIdentifier == null)
+                replicationIdentifier = "unknown";
             str = String.format("PusherInternal{%s, %s, %s}",
                     maskedRemote, type, replicationIdentifier);
         }

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -923,9 +923,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         if (remoteCheckpointDocID != null) {
             return remoteCheckpointDocID;
         } else {
-           if (db == null) {
+            if (db == null || !db.isOpen())
                 return null;
-            }
             return remoteCheckpointDocID(db.privateUUID());
         }
     }


### PR DESCRIPTION
…), fails with recent commit.

- In case database is closed, Pull/PushReplicationInternal.toString() causes NPE because `Database.store` instance variable is `null`. Add db.isOpen() check to prevent NPE.
- Also update toString() to avoid NPE in any case.