### PR TITLE
Fixed #1143 - sequence number is not set in RevisionInternal when Cha…

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
@@ -162,7 +162,7 @@ public class RevisionInternal {
     public RevisionInternal copyWithDocID(String docID, String revID) {
         assert (docID != null);
         assert ((this.docID == null) || (this.docID.equals(docID)));
-        RevisionInternal result = new RevisionInternal(docID, revID, deleted);
+        RevisionInternal rev = new RevisionInternal(docID, revID, deleted);
         Map<String, Object> unmodifiableProperties = getProperties();
         Map<String, Object> properties = new HashMap<String, Object>();
         if (unmodifiableProperties != null) {
@@ -170,8 +170,8 @@ public class RevisionInternal {
         }
         properties.put("_id", docID);
         properties.put("_rev", revID);
-        result.setProperties(properties);
-        return result;
+        rev.setProperties(properties);
+        return rev;
     }
 
     public RevisionInternal copyWithoutBody() {
@@ -194,7 +194,7 @@ public class RevisionInternal {
 
     @Override
     public String toString() {
-        return '{' + this.docID + " #" + this.revID + (deleted ? "DEL" : "") + '}';
+        return '{' + this.docID + " #" + this.revID + " @" + sequence + (deleted ? " DEL" : "") + '}';
     }
 
     /**

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -758,12 +758,10 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                             // if not running state anymore, exit from loop.
                             if (!isRunning())
                                 break;
-                            RevisionInternal nuRev = rev.copy();
-                            nuRev.setBody(null); //save memory
+                            RevisionInternal nuRev = rev.copyWithoutBody();
                             addToInbox(nuRev);
                         } else {
-                            RevisionInternal nuRev = rev.copy();
-                            nuRev.setBody(null); //save memory
+                            RevisionInternal nuRev = rev.copyWithoutBody();
                             queueChanges.add(nuRev);
                         }
                     }


### PR DESCRIPTION
…nges are pull replicated

- RevisionInternal.copy() does not copy sequence. Instead of copy, use `copyWithoutBody()`
- update RevisionInternal.toString() for better information.