### PR TITLE
Fixed #1149 - Push replicator can not retry if push replicator switch…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -120,6 +120,11 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         }
     }
 
+    @Override
+    protected void onBeforeScheduleRetry() {
+        // do nothing
+    }
+
     public boolean isPull() {
         return true;
     }

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -784,9 +784,8 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
     }
 
     @Override
-    protected void retry() {
+    protected void onBeforeScheduleRetry() {
         stopObserving();
-        super.retry();
     }
 
     @Override


### PR DESCRIPTION
… state between IDLE and ACTIVE(RUNNING) too frequently.

Push replicator can not retry if changed() event is faired continuously in less than 60 sec because push replicator cancel & reschedule retry whenever it enters IDLE state.
Solution, if need to reschedule, push replicator stops to observe Database ChangeEvents