### PR TITLE
Fixed #1151 - Pull replicator skipped documents to pull

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -122,7 +122,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     @Override
     protected void onBeforeScheduleRetry() {
-        // do nothing
+        // stop change tracker
+        if (changeTracker != null)
+            changeTracker.stop();
     }
 
     public boolean isPull() {


### PR DESCRIPTION
Pull replicator can not retry (in case of error occurs) if ChangeTracker received changes continuously in less than 60 sec because pull replicator cancel & reschedule retry whenever it enters IDLE state.