### PR TITLE
Fixed #1154 - Should not call `parentReplication.isPull()` from `Repl…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -1027,9 +1027,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             if (remote != null)
                 remote.toExternalForm();
             maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
-            String type = "unknown";
-            if (parentReplication != null)
-                type = parentReplication.isPull() ? "pull" : "push";
+            String type = isPull() ? "pull" : "push";
             String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
             if (replicationIdentifier == null)
                 replicationIdentifier = "unknown";

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -795,9 +795,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
             if (remote != null)
                 maskedRemote = remote.toExternalForm();
             maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
-            String type = "unknown";
-            if (parentReplication != null)
-                type = parentReplication.isPull() ? "pull" : "push";
+            String type = isPull() ? "pull" : "push";
             String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
             if (replicationIdentifier == null)
                 replicationIdentifier = "unknown";

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -356,7 +356,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                     try {
                         String maskedRemote = remote.toExternalForm();
                         maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
-                        String type = parentReplication.isPull()?"pull":"push";
+                        String type = isPull() ? "pull" : "push";
                         String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
                         threadName = String.format("CBLRequestWorker-%s-%s-%s-%d",
                                 maskedRemote, type, replicationIdentifier, counter++);


### PR DESCRIPTION
…icatonInternal`

- `Repliation.isPull()` calls `replicationInternal.isPull()`. So it cycled. If calling `parentReplication.isPull()` in constructor of `ReplicationInternal`, this causes NPE.