### PR TITLE
Fixed #1158 - ReplicationInternal.stop() never executed

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1086,9 +1086,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
      * Actual work of stopping the replication process.
      */
     protected void stop() {
-        if (!isRunning())
-            return;
-
         // clear batcher
         batcher.clear();
         // set non-continuous


### PR DESCRIPTION
- `stop()` method is only called from StateMachine. Just removing `isRunning()` check is good enough