### PR TITLE
FIXED #1141 - Thread-waitForPendingFutures is leaking

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -321,7 +321,13 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
             Future future = pendingRequests.poll(500, TimeUnit.MILLISECONDS);
             if (future == null)
                 continue;
-            future.get();
+            while (!future.isDone() && !future.isCancelled()) {
+                try {
+                    future.get(500, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException te) {
+                    // ignore TimeoutException
+                }
+            }
         }
 
         // exhausted attempts, callback to original caller with result.  requestThrowable


### PR DESCRIPTION
From thread-dump and code review, it seems future is already DONE or CANCELED state when calling `Future.get()`, so it seems notification is not fired. As solution, instead of using `Future.get()`, use `Future.get(timeout, unit)` with checking `isDone()` and `isCanceled()`

Please refer https://github.com/couchbase/couchbase-lite-java-core/issues/1141#issuecomment-201153017