### PR TITLE
FIXED #1147 - [Scenario 4] Missing changes in Database Change Notific…

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -107,7 +107,7 @@ public class Database implements StoreDelegate {
     private Cache<String, Document> docCache;
     final private List<DocumentChange> changesToNotify;
     private boolean postingChangeNotifications;
-    final protected Object lockPostingChangeNotifications = new Object();
+    final private Object lockPostingChangeNotifications = new Object();
     private long startTime;
 
     /**

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -2226,16 +2226,26 @@ public class Database implements StoreDelegate {
 
                 final ChangeEvent changeEvent = new ChangeEvent(this, isExternal, outgoingChanges);
                 synchronized (changeListeners) {
-                    for (ChangeListener changeListener : changeListeners)
-                        changeListener.changed(changeEvent);
+                    for (ChangeListener changeListener : changeListeners) {
+                        if (changeListener != null) {
+                            try {
+                                changeListener.changed(changeEvent);
+                            } catch (Exception ex) {
+                                // Implementation of ChangeListener might throw RuntimeException,
+                                // ignore it.
+                                Log.e(TAG, "%s got exception posting change notification: %s",
+                                        ex, this, changeListener);
+                            }
+                        }
+                    }
                 }
                 posted = true;
             }
             return posted;
         } catch (Exception e) {
             // In general, non of methods that are used in this method throws Exception.
-            // This catch block is just in case RuntimeExcepiton is thrown.
-            Log.e(TAG, "%s got exception posting change notifications", e, this);
+            // This catch block is just in case RuntimeException is thrown.
+            Log.e(TAG, "Unknown Exception: %s got exception posting change notifications", e, this);
             return false;
         } finally {
             synchronized (lockPostingChangeNotifications) {


### PR DESCRIPTION
…ation

As @pasin analyzed, `changesToNotify`, `postingChangeNotifications`, `changeListeners`, and `databaseListeners` variables are not thread-safe. In this scenario, `changeListener` and `databaseListners` are not added/removed in concurrent env. These two variables don't directly cause the problem with under unit-test scenario. `changesToNotify` and `postingChangeNotifications` makes test fails. Especially, `changesToNotify`  variable. By this commit, make all four variables thread-safe. And make `postChangeNotifications()` method thread-safe by `postingChangeNotifications` variable and `lockPostingChangeNotifications` lock object.

I run `testDatabaseChangeNotification()` unit test with this fix many times with Genymotion emulator (faster test env) and Stock Emulator ARM API 19 (slower test env). With this fix, the test never failed again. I also all unit test with this fix with both genymotion and ARM API 19 emulator. And test passed.