### PR TITLE
Fixed Android Issue 834 - ConcurrentModificationException when try to…

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -88,9 +88,9 @@ public class Database implements StoreDelegate {
     public static int DEFAULT_MAX_REVS = 20;
 
     private Store store = null;
-    final private String path;
+    private final String path;
     private String name;
-    final private AtomicBoolean open = new AtomicBoolean(false);
+    private final AtomicBoolean open = new AtomicBoolean(false);
 
     private Map<String, View> views;
     private Map<String, String> viewDocTypes;
@@ -98,18 +98,18 @@ public class Database implements StoreDelegate {
     private Map<String, Validator> validations;
 
     private Map<String, Object> pendingAttachmentsByDigest;
-    final private Set<Replication> activeReplicators;
-    final private Set<Replication> allReplicators;
+    private final Set<Replication> activeReplicators;
+    private final Set<Replication> allReplicators;
 
     private BlobStore attachments;
-    final private Manager manager;
-    final private Set<ChangeListener> changeListeners;
-    final private Set<DatabaseListener> databaseListeners;
-    final private Cache<String, Document> docCache;
-    final private List<DocumentChange> changesToNotify;
+    private final Manager manager;
+    private final Set<ChangeListener> changeListeners;
+    private final Set<DatabaseListener> databaseListeners;
+    private final Cache<String, Document> docCache;
+    private final List<DocumentChange> changesToNotify;
     private boolean postingChangeNotifications;
-    final private Object lockPostingChangeNotifications = new Object();
-    final private long startTime;
+    private final Object lockPostingChangeNotifications = new Object();
+    private final long startTime;
 
     /**
      * Each database can have an associated PersistentCookieStore,

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -58,6 +58,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -87,7 +88,7 @@ public class Database implements StoreDelegate {
     public static int DEFAULT_MAX_REVS = 20;
 
     private Store store = null;
-    private String path;
+    final private String path;
     private String name;
     final private AtomicBoolean open = new AtomicBoolean(false);
 
@@ -97,18 +98,18 @@ public class Database implements StoreDelegate {
     private Map<String, Validator> validations;
 
     private Map<String, Object> pendingAttachmentsByDigest;
-    private Set<Replication> activeReplicators;
-    private Set<Replication> allReplicators;
+    final private Set<Replication> activeReplicators;
+    final private Set<Replication> allReplicators;
 
     private BlobStore attachments;
-    private Manager manager;
+    final private Manager manager;
     final private Set<ChangeListener> changeListeners;
     final private Set<DatabaseListener> databaseListeners;
-    private Cache<String, Document> docCache;
+    final private Cache<String, Document> docCache;
     final private List<DocumentChange> changesToNotify;
     private boolean postingChangeNotifications;
     final private Object lockPostingChangeNotifications = new Object();
-    private long startTime;
+    final private long startTime;
 
     /**
      * Each database can have an associated PersistentCookieStore,
@@ -140,7 +141,7 @@ public class Database implements StoreDelegate {
         this.name = name != null ? name : FileDirUtils.getDatabaseNameFromPath(path);
         this.manager = manager;
         this.startTime = System.currentTimeMillis();
-        this.changeListeners = Collections.synchronizedSet(new HashSet<ChangeListener>());
+        this.changeListeners = new CopyOnWriteArraySet<ChangeListener>();
         this.databaseListeners = Collections.synchronizedSet(new HashSet<DatabaseListener>());
         this.docCache = new Cache<String, Document>();
         this.changesToNotify = Collections.synchronizedList(new ArrayList<DocumentChange>());
@@ -188,7 +189,9 @@ public class Database implements StoreDelegate {
     @InterfaceAudience.Public
     public List<Replication> getAllReplications() {
         List<Replication> allReplicatorsList = new ArrayList<Replication>();
-        allReplicatorsList.addAll(allReplicators);
+        synchronized (allReplicators) {
+            allReplicatorsList.addAll(allReplicators);
+        }
         return allReplicatorsList;
     }
 
@@ -2225,17 +2228,15 @@ public class Database implements StoreDelegate {
                 }
 
                 final ChangeEvent changeEvent = new ChangeEvent(this, isExternal, outgoingChanges);
-                synchronized (changeListeners) {
-                    for (ChangeListener changeListener : changeListeners) {
-                        if (changeListener != null) {
-                            try {
-                                changeListener.changed(changeEvent);
-                            } catch (Exception ex) {
-                                // Implementation of ChangeListener might throw RuntimeException,
-                                // ignore it.
-                                Log.e(TAG, "%s got exception posting change notification: %s",
-                                        ex, this, changeListener);
-                            }
+                for (ChangeListener changeListener : changeListeners) {
+                    if (changeListener != null) {
+                        try {
+                            changeListener.changed(changeEvent);
+                        } catch (Exception ex) {
+                            // Implementation of ChangeListener might throw RuntimeException,
+                            // ignore it.
+                            Log.e(TAG, "%s got exception posting change notification: %s",
+                                    ex, this, changeListener);
                         }
                     }
                 }

--- a/src/main/java/com/couchbase/lite/DatabaseUpgrade.java
+++ b/src/main/java/com/couchbase/lite/DatabaseUpgrade.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * Couchbase Lite library. If it's not present, Couchbase Lite will ignore old v1.0 databases
  * instead of importing them.
  */
-final public class DatabaseUpgrade {
+public final class DatabaseUpgrade {
     private static String TAG = Log.TAG_DATABASE;
 
     private Manager manager;

--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A CouchbaseLite document.
@@ -33,7 +34,7 @@ public class Document {
     /**
      * Change Listeners
      */
-    private List<ChangeListener> changeListeners = Collections.synchronizedList(new ArrayList<ChangeListener>());
+    final private List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
 
     /**
      * Constructor
@@ -483,9 +484,8 @@ public class Document {
     @InterfaceAudience.Private
     protected void revisionAdded(DocumentChange change, boolean notify) {
         String revID = change.getWinningRevisionID();
-        if (revID == null) {
+        if (revID == null)
             return;  // current revision didn't change
-        }
 
         if (currentRevision != null && !revID.equals(currentRevision.getId())) {
             RevisionInternal rev = change.getWinningRevisionIfKnown();
@@ -498,11 +498,8 @@ public class Document {
         }
 
         if (notify) {
-            synchronized (changeListeners) {
-                for (ChangeListener listener : changeListeners) {
-                    listener.changed(new ChangeEvent(this, change));
-                }
-            }
+            for (ChangeListener listener : changeListeners)
+                listener.changed(new ChangeEvent(this, change));
         }
     }
 

--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -34,7 +34,7 @@ public class Document {
     /**
      * Change Listeners
      */
-    final private List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
+    private final List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
 
     /**
      * Constructor

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -15,8 +15,6 @@ import com.couchbase.lite.support.PersistentCookieStore;
 import com.couchbase.lite.util.Log;
 
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -78,7 +76,7 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
     protected ScheduledExecutorService workExecutor;
     protected ReplicationInternal replicationInternal;
     protected Lifecycle lifecycle;
-    final private List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
+    private final List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
     protected Throwable lastError;
     protected Direction direction;
 
@@ -537,11 +535,11 @@ public class Replication implements ReplicationInternal.ChangeListener, NetworkR
     @InterfaceAudience.Public
     public static class ChangeEvent {
 
-        final private Replication source;
-        final private int changeCount;
-        final private int completedChangeCount;
-        final private ReplicationStateTransition transition;
-        final private Throwable error;
+        private final Replication source;
+        private final int changeCount;
+        private final int completedChangeCount;
+        private final ReplicationStateTransition transition;
+        private final Throwable error;
 
         protected ChangeEvent(ReplicationInternal replInternal) {
             this.source = replInternal.parentReplication;

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -115,7 +115,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected ScheduledExecutorService workExecutor;
 
     protected StateMachine<ReplicationState, ReplicationTrigger> stateMachine;
-    final private List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
+    private final List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
     protected Replication.Lifecycle lifecycle;
     protected ChangeListenerNotifyStyle changeListenerNotifyStyle;
 
@@ -123,7 +123,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
     // for waitingPendingFutures
     protected boolean waitingForPendingFutures = false;
-    final protected Object lockWaitForPendingFutures = new Object();
+    protected final Object lockWaitForPendingFutures = new Object();
 
     /**
      * Constructor

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -133,7 +133,7 @@ public class Utils {
     /**
      * cribbed from http://stackoverflow.com/questions/9655181/convert-from-byte-array-to-hex-string-in-java
      */
-    final protected static char[] hexArray = "0123456789abcdef".toCharArray();
+    protected static final char[] hexArray = "0123456789abcdef".toCharArray();
 
     public static String bytesToHex(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];


### PR DESCRIPTION
… update object

- Ticket: https://github.com/couchbase/couchbase-lite-android/issues/834

- Use `CopyOnWriteArraySet` or `CopyOnWriteArrayList` for Set/List of changeListener. CopyOnWriteArraySet/CopyOnWriteArrayList creates copy of array for iteration, so it does not cause `ConcurrentModificationException` and it is thread-safe.
- Except `changeListeners`, not applied CopyOnWriteArraySet/CopyOnWriteArrayList
- In addition, applied `final` for variables that should not be changed.