### PR TITLE
Fixed #1162 - CustomLinkedBlockingQueue does not send notification fo…

### DIFF
--- a/src/main/java/com/couchbase/lite/support/BlockingQueueListener.java
+++ b/src/main/java/com/couchbase/lite/support/BlockingQueueListener.java
@@ -6,7 +6,7 @@ import java.util.concurrent.BlockingQueue;
  * Created by hideki on 12/17/14.
  */
 public interface BlockingQueueListener<E> {
-    enum EventType {ADD, PUT, TAKE}
+    enum EventType {ADD, PUT, TAKE, POLL}
 
     void changed(EventType type, E e, BlockingQueue<E> queue);
 }

--- a/src/main/java/com/couchbase/lite/support/CustomLinkedBlockingQueue.java
+++ b/src/main/java/com/couchbase/lite/support/CustomLinkedBlockingQueue.java
@@ -2,6 +2,7 @@ package com.couchbase.lite.support;
 
 import java.util.Collection;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by hideki on 12/17/14.
@@ -57,7 +58,24 @@ public class CustomLinkedBlockingQueue<E> extends LinkedBlockingQueue<E> {
         if(listener != null) {
             listener.changed(BlockingQueueListener.EventType.TAKE, e, this);
         }
+        return e;
+    }
 
+    @Override
+    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+        E e = super.poll(timeout, unit);
+        if (listener != null) {
+            listener.changed(BlockingQueueListener.EventType.POLL, e, this);
+        }
+        return e;
+    }
+
+    @Override
+    public E poll() {
+        E e = super.poll();
+        if (listener != null) {
+            listener.changed(BlockingQueueListener.EventType.POLL, e, this);
+        }
         return e;
     }
 }


### PR DESCRIPTION
…r poll()

- support callback for `poll()` methods
- currently CBL does not handle event for TAKE or POLL. This change does not make impact to functionality.