### PR TITLE
Fixed #840 - SQLiteStore not support auto compact

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -84,6 +84,8 @@ public class Database implements StoreDelegate {
     // Length that constitutes a 'big' attachment
     public static int kBigAttachmentLength = (2 * 1024);
 
+    private static boolean autoCompact = true;
+
     // Default value for maxRevTreeDepth, the max rev depth to preserve in a prune operation
     public static int DEFAULT_MAX_REVS = 20;
 
@@ -1012,6 +1014,11 @@ public class Database implements StoreDelegate {
     ///////////////////////////////////////////////////////////////////////////
 
     @InterfaceAudience.Private
+    public static void setAutoCompact(boolean autoCompact) {
+        Database.autoCompact = autoCompact;
+    }
+
+    @InterfaceAudience.Private
     public interface DatabaseListener {
         void databaseClosing();
     }
@@ -1132,6 +1139,7 @@ public class Database implements StoreDelegate {
         }
 
         store = primaryStore;
+        store.setAutoCompact(autoCompact);
 
         // Set encryption key:
         SymmetricKey encryptionKey = null;

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -132,6 +132,7 @@ public class SQLiteStore implements Store, EncryptableStore {
     private TransactionLevel transactionLevel;
     private StoreDelegate delegate;
     private int maxRevTreeDepth;
+    private boolean autoCompact;
     private SymmetricKey encryptionKey;
     private final Object compactLock = new Object(); // lock for compact() method
 
@@ -350,6 +351,16 @@ public class SQLiteStore implements Store, EncryptableStore {
     @Override
     public int getMaxRevTreeDepth() {
         return maxRevTreeDepth;
+    }
+
+    @Override
+    public void setAutoCompact(boolean value) {
+        autoCompact = value;
+    }
+
+    @Override
+    public boolean getAutoCompact() {
+        return autoCompact;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/couchbase/lite/store/Store.java
+++ b/src/main/java/com/couchbase/lite/store/Store.java
@@ -66,9 +66,9 @@ public interface Store {
      * Whether the database storage should automatically (periodically) be compacted.
      * This will be set soon after the open() method call.
      */
-    //void setAutoCompact(boolean value);
+    void setAutoCompact(boolean value);
 
-    //boolean getAutoCompact();
+    boolean getAutoCompact();
 
     ///////////////////////////////////////////////////////////////////////////
     // DATABASE ATTRIBUTES & OPERATIONS:


### PR DESCRIPTION
- iOS does not support autoCompact for SQLiteStore
- Implemented autoCompact for ForestDB. Current implementation was not sufficient.
- Add interface to enable/disable autoCompact