### PR TITLE
Fixed #820 - Filter out _removed revision from push replication

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -383,6 +383,13 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                                 continue;
                             }
 
+                            if (loadedRev.getPropertyForKey("_removed") != null &&
+                                    ((Boolean) loadedRev.getPropertyForKey("_removed")).booleanValue()) {
+                                // Filter out _removed revision:
+                                removePending(rev);
+                                continue;
+                            }
+
                             RevisionInternal populatedRev = transformRevision(loadedRev);
 
                             List<String> possibleAncestors = (List<String>) revResults.get("possible_ancestors");


### PR DESCRIPTION
- Ported from https://github.com/couchbase/couchbase-lite-ios/pull/776
- If _removed property value is true, skip its revision for push replication.