### PR TITLE
Fixed Android Issue 863 - LiveQuery is blocked by replicator

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -316,8 +315,7 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Public
     public Replication createPullReplication(URL remote) {
-        return new Replication(this, remote, Replication.Direction.PULL, null,
-                manager.getWorkExecutor());
+        return new Replication(this, remote, Replication.Direction.PULL, null);
 
     }
 
@@ -329,8 +327,7 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Public
     public Replication createPushReplication(URL remote) {
-        return new Replication(this, remote, Replication.Direction.PUSH, null,
-                manager.getWorkExecutor());
+        return new Replication(this, remote, Replication.Direction.PUSH, null);
     }
 
     /**
@@ -2287,18 +2284,15 @@ public class Database implements StoreDelegate {
     protected Replication getReplicator(URL remote,
                                         HttpClientFactory httpClientFactory,
                                         boolean push,
-                                        boolean continuous,
-                                        ScheduledExecutorService workExecutor) {
+                                        boolean continuous) {
         Replication result = getActiveReplicator(remote, push);
         if (result != null) {
             return result;
         }
         if (push) {
-            result = new Replication(this, remote, Replication.Direction.PUSH,
-                    httpClientFactory, workExecutor);
+            result = new Replication(this, remote, Replication.Direction.PUSH, httpClientFactory);
         } else {
-            result = new Replication(this, remote, Replication.Direction.PULL,
-                    httpClientFactory, workExecutor);
+            result = new Replication(this, remote, Replication.Direction.PULL, httpClientFactory);
         }
         result.setContinuous(continuous);
         return result;

--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -646,21 +646,25 @@ public final class Manager {
 
         // Can't specify both a filter and doc IDs
         if (properties.get("filter") != null && properties.get("doc_ids") != null)
-            throw new CouchbaseLiteException("Can't specify both a filter and doc IDs", new Status(Status.BAD_REQUEST));
+            throw new CouchbaseLiteException("Can't specify both a filter and doc IDs",
+                    new Status(Status.BAD_REQUEST));
 
         try {
             remote = new URL(remoteStr);
         } catch (MalformedURLException e) {
-            throw new CouchbaseLiteException("malformed remote url: " + remoteStr, new Status(Status.BAD_REQUEST));
+            throw new CouchbaseLiteException("malformed remote url: " + remoteStr,
+                    new Status(Status.BAD_REQUEST));
         }
         if (remote == null) {
-            throw new CouchbaseLiteException("remote URL is null: " + remoteStr, new Status(Status.BAD_REQUEST));
+            throw new CouchbaseLiteException("remote URL is null: " + remoteStr,
+                    new Status(Status.BAD_REQUEST));
         }
 
         if (!cancel) {
-            repl = db.getReplicator(remote, getDefaultHttpClientFactory(), push, continuous, getWorkExecutor());
+            repl = db.getReplicator(remote, getDefaultHttpClientFactory(), push, continuous);
             if (repl == null) {
-                throw new CouchbaseLiteException("unable to create replicator with remote: " + remote, new Status(Status.INTERNAL_SERVER_ERROR));
+                throw new CouchbaseLiteException("unable to create replicator with remote: " + remote,
+                        new Status(Status.INTERNAL_SERVER_ERROR));
             }
 
             if (authorizer != null) {
@@ -705,7 +709,8 @@ public final class Manager {
             // Cancel replication:
             repl = db.getActiveReplicator(remote, push);
             if (repl == null) {
-                throw new CouchbaseLiteException("unable to lookup replicator with remote: " + remote, new Status(Status.NOT_FOUND));
+                throw new CouchbaseLiteException("unable to lookup replicator with remote: " + remote,
+                        new Status(Status.NOT_FOUND));
             }
         }
 

--- a/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
+++ b/src/main/java/com/couchbase/lite/replicator/BulkDownloader.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.GZIPInputStream;
 
@@ -41,7 +40,6 @@ import java.util.zip.GZIPInputStream;
  */
 @InterfaceAudience.Private
 public class BulkDownloader extends RemoteRequest implements MultipartReaderDelegate {
-
     public static final String TAG = Log.TAG_SYNC;
 
     private Database db;
@@ -49,17 +47,14 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
     private MultipartDocumentReader _docReader;
     private BulkDownloaderDocumentBlock _onDocument;
 
-    public BulkDownloader(ScheduledExecutorService workExecutor,
-                          HttpClientFactory clientFactory,
+    public BulkDownloader(HttpClientFactory clientFactory,
                           URL dbURL,
                           List<RevisionInternal> revs,
                           Database database,
                           Map<String, Object> requestHeaders,
                           BulkDownloaderDocumentBlock onDocument,
                           RemoteRequestCompletionBlock onCompletion) throws Exception {
-
-        super(workExecutor,
-                clientFactory,
+        super(clientFactory,
                 "POST",
                 new URL(buildRelativeURLString(dbURL, "/_bulk_get?revs=true&attachments=true")),
                 helperMethod(revs, database),
@@ -69,7 +64,6 @@ public class BulkDownloader extends RemoteRequest implements MultipartReaderDele
 
         db = database;
         _onDocument = onDocument;
-
     }
 
     @Override

--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * @exclude
@@ -74,10 +73,9 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
     public PusherInternal(Database db,
                           URL remote,
                           HttpClientFactory clientFactory,
-                          ScheduledExecutorService workExecutor,
                           Replication.Lifecycle lifecycle,
                           Replication parentReplication) {
-        super(db, remote, clientFactory, workExecutor, lifecycle, parentReplication);
+        super(db, remote, clientFactory, lifecycle, parentReplication);
     }
 
     @Override

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -63,23 +63,18 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @InterfaceAudience.Private
 abstract class ReplicationInternal implements BlockingQueueListener {
-
     private static final String TAG = Log.TAG_SYNC;
+    public static final String BY_CHANNEL_FILTER_NAME = "sync_gateway/bychannel";
+    public static final String CHANNELS_QUERY_PARAM = "channels";
+    public static final int EXECUTOR_THREAD_POOL_SIZE = 5;
+
+    private static int lastSessionID = 0;
+    public static int RETRY_DELAY_SECONDS = 60; // #define kRetryDelay 60.0 in CBL_Replicator.m
 
     // Change listeners can be called back synchronously or asynchronously.
     protected enum ChangeListenerNotifyStyle {
         SYNC, ASYNC
     }
-
-    public static final String BY_CHANNEL_FILTER_NAME = "sync_gateway/bychannel";
-
-    public static final String CHANNELS_QUERY_PARAM = "channels";
-
-    public static final int EXECUTOR_THREAD_POOL_SIZE = 5;
-
-    private static int lastSessionID = 0;
-
-    public static int RETRY_DELAY_SECONDS = 60; // #define kRetryDelay 60.0 in CBL_Replicator.m
 
     protected Replication parentReplication;
     protected Database db;
@@ -110,8 +105,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     private boolean overdueForCheckpointSave;
 
     // the code assumes this is a _single threaded_ work executor.
-    // if it's not, the behavior will be buggy.  I don't see a way to assert this in the code.
-    protected ScheduledExecutorService workExecutor;
+    protected ScheduledExecutorService executor;
 
     protected StateMachine<ReplicationState, ReplicationTrigger> stateMachine;
     private final List<ChangeListener> changeListeners = new CopyOnWriteArrayList<ChangeListener>();
@@ -129,7 +123,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
      */
     ReplicationInternal(Database db, URL remote,
                         HttpClientFactory clientFactory,
-                        ScheduledExecutorService workExecutor,
                         Replication.Lifecycle lifecycle,
                         Replication parentReplication) {
 
@@ -139,7 +132,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         this.db = db;
         this.remote = remote;
         this.clientFactory = clientFactory;
-        this.workExecutor = workExecutor;
         this.lifecycle = lifecycle;
         this.requestHeaders = new HashMap<String, Object>();
 
@@ -159,7 +151,18 @@ abstract class ReplicationInternal implements BlockingQueueListener {
 
         pendingFutures = new CustomLinkedBlockingQueue<Future>(this);
 
+        initializeReplicationExecutor();
+
         initializeStateMachine();
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        if (executor != null && !executor.isShutdown()) {
+            Utils.shutdownAndAwaitTermination(executor);
+            executor = null;
+        }
+        super.finalize();
     }
 
     /**
@@ -196,9 +199,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected void fireTrigger(final ReplicationTrigger trigger) {
         Log.d(Log.TAG_SYNC, "%s [fireTrigger()] => " + trigger, this);
         // All state machine triggers need to happen on the replicator thread
-        synchronized (workExecutor) {
-            if (!workExecutor.isShutdown()) {
-                workExecutor.submit(new Runnable() {
+        synchronized (executor) {
+            if (!executor.isShutdown()) {
+                executor.submit(new Runnable() {
                     @Override
                     public void run() {
                         try {
@@ -303,8 +306,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     }
 
     protected void initBatcher() {
-
-        batcher = new Batcher<RevisionInternal>(workExecutor, INBOX_CAPACITY, PROCESSOR_DELAY, new BatchProcessor<RevisionInternal>() {
+        batcher = new Batcher<RevisionInternal>(executor, INBOX_CAPACITY, PROCESSOR_DELAY, new BatchProcessor<RevisionInternal>() {
             @Override
             public void process(List<RevisionInternal> inbox) {
 
@@ -318,8 +320,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 }
             }
         });
-
-
     }
 
     protected void startNetworkReachabilityManager() {
@@ -339,6 +339,28 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     public abstract boolean shouldCreateTarget();
 
     public abstract void setCreateTarget(boolean createTarget);
+
+    protected void initializeReplicationExecutor() {
+        if (executor == null) {
+            executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    String threadName = "CBLReplicationExecutor";
+                    try {
+                        String maskedRemote = ReplicationInternal.this.remote.toExternalForm();
+                        maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
+                        String type = isPull() ? "pull" : "push";
+                        String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);
+                        threadName = String.format("CBLReplicationExecutor-%s-%s-%s",
+                                maskedRemote, type, replicationIdentifier);
+                    } catch (Exception e) {
+                        Log.e(Log.TAG_SYNC, "Error creating thread name", e);
+                    }
+                    return new Thread(r, threadName);
+                }
+            });
+        }
+    }
 
     protected void initializeRequestWorkers() {
         if (remoteRequestExecutor == null) {
@@ -554,7 +576,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         RemoteRequestRetry request = new RemoteRequestRetry(
                 RemoteRequestRetry.RemoteRequestType.REMOTE_REQUEST,
                 remoteRequestExecutor,
-                workExecutor,
+                executor,
                 clientFactory,
                 method,
                 url,
@@ -603,7 +625,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         RemoteRequestRetry request = new RemoteRequestRetry(
                 RemoteRequestRetry.RemoteRequestType.REMOTE_MULTIPART_REQUEST,
                 remoteRequestExecutor,
-                workExecutor,
+                executor,
                 clientFactory,
                 method,
                 url,
@@ -633,7 +655,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
             RemoteRequestRetry request = new RemoteRequestRetry(
                     RemoteRequestRetry.RemoteRequestType.REMOTE_MULTIPART_DOWNLOADER_REQUEST,
                     remoteRequestExecutor,
-                    workExecutor,
+                    executor,
                     clientFactory,
                     method,
                     url,
@@ -790,8 +812,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     }
 
     protected void setLastSequenceFromWorkExecutor(final String lastSequence, final String checkpointId) {
-        // write access to database from workExecutor
-        workExecutor.submit(new Runnable() {
+        // write access to database from executor
+        executor.submit(new Runnable() {
             @Override
             public void run() {
                 if (db != null && db.isOpen())
@@ -1112,9 +1134,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
             }
         } else {
             // ASYNC
-            synchronized (workExecutor) {
-                if (!workExecutor.isShutdown()) {
-                    workExecutor.submit(new Runnable() {
+            synchronized (executor) {
+                if (!executor.isShutdown()) {
+                    executor.submit(new Runnable() {
                         @Override
                         public void run() {
                             try {
@@ -1297,7 +1319,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         stateMachine.configure(ReplicationState.STOPPED).onEntry(new Action1<Transition<ReplicationState, ReplicationTrigger>>() {
             @Override
             public void doIt(Transition<ReplicationState, ReplicationTrigger> transition) {
-                Log.v(Log.TAG_SYNC, "%s [onEntry()] " + transition.getSource() + " => " + transition.getDestination(), ReplicationInternal.this.toString());
+                Log.v(Log.TAG_SYNC,
+                        "%s [onEntry()] " + transition.getSource() + " => " + transition.getDestination(),
+                        ReplicationInternal.this.toString());
 
                 // NOTE: Based on StateMachine configuration, this should not happen.
                 //       However, from Unit Test result, this could be happen.
@@ -1324,7 +1348,8 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     }
 
     private void logTransition(Transition<ReplicationState, ReplicationTrigger> transition) {
-        Log.d(Log.TAG_SYNC, "State transition: %s -> %s (via %s).  this: %s", transition.getSource(), transition.getDestination(), transition.getTrigger(), this);
+        Log.d(Log.TAG_SYNC, "State transition: %s -> %s (via %s).  this: %s",
+                transition.getSource(), transition.getDestination(), transition.getTrigger(), this);
     }
 
     private void notifyChangeListenersStateTransition(Transition<ReplicationState, ReplicationTrigger> transition) {
@@ -1410,7 +1435,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
      */
     private void scheduleRetryFuture() {
         Log.v(Log.TAG_SYNC, "%s: Failed to xfer; will retry in %d sec", this, RETRY_DELAY_SECONDS);
-        this.retryFuture = workExecutor.schedule(new Runnable() {
+        this.retryFuture = executor.schedule(new Runnable() {
             public void run() {
                 retryIfReady();
             }
@@ -1489,7 +1514,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
             lastSequence = lastSequenceIn;
             if (!lastSequenceChanged) {
                 lastSequenceChanged = true;
-                workExecutor.schedule(new Runnable() {
+                executor.schedule(new Runnable() {
                     public void run() {
                         saveLastSequence();
                     }

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartDownloaderRequest.java
@@ -18,17 +18,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.zip.GZIPInputStream;
 
 public class RemoteMultipartDownloaderRequest extends RemoteRequest {
 
     private Database db;
 
-    public RemoteMultipartDownloaderRequest(ScheduledExecutorService workExecutor,
-                                            HttpClientFactory clientFactory, String method, URL url,
-                                            Object body, Database db, Map<String, Object> requestHeaders, RemoteRequestCompletionBlock onCompletion) {
-        super(workExecutor, clientFactory, method, url, body, db, requestHeaders, onCompletion);
+    public RemoteMultipartDownloaderRequest(HttpClientFactory clientFactory,
+                                            String method,
+                                            URL url,
+                                            Object body,
+                                            Database db,
+                                            Map<String, Object> requestHeaders,
+                                            RemoteRequestCompletionBlock onCompletion) {
+        super(clientFactory, method, url, body, db, requestHeaders, onCompletion);
         this.db = db;
     }
 

--- a/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteMultipartRequest.java
@@ -10,16 +10,19 @@ import org.apache.http.client.methods.HttpUriRequest;
 
 import java.net.URL;
 import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
 
 public class RemoteMultipartRequest extends RemoteRequest {
 
     private MultipartEntity multiPart = null;
 
-    public RemoteMultipartRequest(ScheduledExecutorService workExecutor,
-                                  HttpClientFactory clientFactory, String method, URL url,
-                                  MultipartEntity multiPart, Database db, Map<String, Object> requestHeaders, RemoteRequestCompletionBlock onCompletion) {
-        super(workExecutor, clientFactory, method, url, null, db, requestHeaders, onCompletion);
+    public RemoteMultipartRequest(HttpClientFactory clientFactory,
+                                  String method,
+                                  URL url,
+                                  MultipartEntity multiPart,
+                                  Database db,
+                                  Map<String, Object> requestHeaders,
+                                  RemoteRequestCompletionBlock onCompletion) {
+        super(clientFactory, method, url, null, db, requestHeaders, onCompletion);
         this.multiPart = multiPart;
     }
 

--- a/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/support/RemoteRequestRetry.java
@@ -76,7 +76,6 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
         this.queue = queue;
     }
 
-
     /**
      * The kind of RemoteRequest that will be created on each retry attempt
      */
@@ -145,7 +144,6 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
         switch (requestType) {
             case REMOTE_MULTIPART_REQUEST:
                 request = new RemoteMultipartRequest(
-                        workExecutor,
                         clientFactory,
                         method,
                         url,
@@ -156,7 +154,6 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
                 break;
             case REMOTE_MULTIPART_DOWNLOADER_REQUEST:
                 request = new RemoteMultipartDownloaderRequest(
-                        workExecutor,
                         clientFactory,
                         method,
                         url,
@@ -167,7 +164,6 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
                 break;
             default:
                 request = new RemoteRequest(
-                        workExecutor,
                         clientFactory,
                         method,
                         url,


### PR DESCRIPTION
This commit is second step to fix issue 863: replicator own own executor service instead of using workExecutor.

Area needs your attention: 
- With this commit, the executor is shutdown in `finalize()` of `ReplicationInternal`. I am not 100% sure if it is ok. Ideally `ExecuterService.shutdown()` should be called out-side of GC.
- If app keeps creating new Replicator, thread leak is caused till app close Database because database holds all replicators which also hold ReplicationInternal.