### PR TITLE
Fixed #1222 - Make SQLite one writer and one/multiple reader modes to…

### DIFF
--- a/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
@@ -76,6 +76,7 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
             if (hasError && database != null)
                 database.close();
         }
+
         return database.isOpen();
     }
 

--- a/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
@@ -60,7 +60,8 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
 
             SQLiteDatabase.setDatabasePlatformSupport(getDatabasePlatformSupport());
             database = SQLiteDatabase.openDatabase(path, null,
-                    SQLiteDatabase.CREATE_IF_NECESSARY, null, new ConnectionListener());
+                    SQLiteDatabase.CREATE_IF_NECESSARY | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING,
+                    null, new ConnectionListener());
             Log.v(Log.TAG_DATABASE, "%s: Opened Android sqlite db", this);
         } catch(SQLiteDatabaseCorruptException e) {
             hasError = true;

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -221,13 +221,8 @@ public class SQLiteStore implements Store, EncryptableStore {
         }
 
         // Enable Write-Ahead Log (WAL)
-        try {
-            initialize("PRAGMA journal_mode=WAL;");
-        } catch (SQLException e) {
-            String message = "Cannot set journal_mode=WAL";
-            Log.e(TAG, message, e);
-            throw new CouchbaseLiteException(message, e, Status.DB_ERROR);
-        }
+        // write-ahead log is enabled through SQLiteDatabase API
+        // https://developer.android.com/reference/android/database/sqlite/SQLiteDatabase.html#enableWriteAheadLogging()
 
         // BEGIN TRANSACTION
         boolean isSuccessful = false;
@@ -673,6 +668,7 @@ public class SQLiteStore implements Store, EncryptableStore {
                 endTransaction(shouldCommit);
             }
 
+            // https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
             Log.v(TAG, "Flushing SQLite WAL...");
             try {
                 storageEngine.execSQL("PRAGMA wal_checkpoint(RESTART)");

--- a/vendor/sqlite/src/java/com/couchbase/lite/internal/database/sqlite/SQLiteConnection.java
+++ b/vendor/sqlite/src/java/com/couchbase/lite/internal/database/sqlite/SQLiteConnection.java
@@ -200,11 +200,16 @@ public final class SQLiteConnection implements CancellationSignal.OnCancelListen
 
         // As we are making this portable, we will not set any configuration here:
         // Still leaving the methods in this class for future references.
-        //setPageSize();
-        //setForeignKeyModeFromConfiguration();
-        //setWalModeFromConfiguration();
-        //setJournalSizeLimit();
-        //setAutoCheckpointInterval();
+
+        // Use the default page size from the sqlite instead
+        // setPageSize();
+
+        setForeignKeyModeFromConfiguration();
+
+        // For WAL Mode:
+        setWalModeFromConfiguration();
+        setJournalSizeLimit();
+        setAutoCheckpointInterval();
     }
 
     private void dispose(boolean finalized) {


### PR DESCRIPTION
… avoid waiting connection.

- Enable WAL through SQLiteDatabase. Set `ENABLE_WRITE_AHEAD_LOGGING` to `SQLiteDatabase.openDatabase()`.
- By using WAL through SQLiteDatabase, SQLiteDatabase open maximum 4 connection to the database.