### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/880 …

### DIFF
--- a/src/main/java/com/couchbase/lite/store/SQLiteViewStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteViewStore.java
@@ -1053,7 +1053,7 @@ public class SQLiteViewStore implements ViewStore, QueryRowStore {
 
     private String mapTableName() {
         if (_mapTableName == null) {
-            _mapTableName = String.format("%d", getViewID());
+            _mapTableName = String.valueOf(getViewID());
         }
         return _mapTableName;
     }


### PR DESCRIPTION
…- SQLiteException: no such table: maps_١ (code 1)

- It seems `String.format("%d", getViewID())` localizes integer to set language string.
- Instead, use `String.valueOf(int)`