### PR TITLE
Fixed #1263 and #1271 closing stream exception when stoping ChangeTracker

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -509,15 +509,7 @@ public class ChangeTracker implements Runnable {
 
         if (call != null) {
             Log.d(Log.TAG_CHANGE_TRACKER, "%s: Changed tracker aborting request: %s", this, request);
-            //request.abort();
             call.cancel();
-        }
-        if (inputStream != null) {
-            try {
-                inputStream.close();
-                inputStream = null;
-            } catch (IOException ex) {
-            }
         }
 
         try {


### PR DESCRIPTION
OkHttp doesn't allow to close the stream from another thread while the stream is inused by the other thread that created the stream. The ChangeTracker.stop() method already calls call.cancel() which will interrupt the current in progress HTTP request and the pending stream should get closed from the final block. Hence there is no need to close the stream in the stop() method.

#1263 #1271