### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/901

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -1293,7 +1293,6 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             @Override
             public boolean run() {
                 boolean ok = false;
-
                 try {
                     for (Map<String, Object> doc : docs) {
                         String docID = (String) doc.get("_id");
@@ -1318,7 +1317,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                         if (status.isSuccessful()) {
                             result = new HashMap<String, Object>();
                             result.put("ok", true);
-                            result.put("id", rev.getDocID());
+                            result.put("id", docID);
                             if (rev != null) {
                                 result.put("rev", rev.getRevID());
                             }
@@ -1327,11 +1326,11 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                         } else if (status.getCode() == Status.FORBIDDEN) {
                             result = new HashMap<String, Object>();
                             result.put("error", "validation failed");
-                            result.put("id", rev.getDocID());
+                            result.put("id", docID);
                         } else if (status.getCode() == Status.CONFLICT) {
                             result = new HashMap<String, Object>();
                             result.put("error", "conflict");
-                            result.put("id", rev.getDocID());
+                            result.put("id", docID);
                         } else {
                             //return status;  // abort the whole thing if something goes badly wrong
                             return false;


### PR DESCRIPTION
NPE when doc saved

- It seems `rev` is `null` in some cases. Instead of using `rev.getDocID()`, use `docID`.