### PR TITLE
Fixed #1280 GET attachment without content-type not returning content

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/AttachmentInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/AttachmentInternal.java
@@ -162,7 +162,8 @@ public class AttachmentInternal {
         Map<String, Object> dict = new HashMap<String, Object>();
         dict.put("stub", true);
         dict.put("digest", blobKey.base64Digest());
-        dict.put("content_type", contentType);
+        if (contentType != null)
+            dict.put("content_type", contentType);
         dict.put("revpos", revpos);
         dict.put("length", length);
         if (encodedLength > 0)

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -631,8 +631,10 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
 
             connection.setResponseCode(status.getCode());
 
-            if (status.isSuccessful() && connection.getResponseBody() == null &&
-                    connection.getHeaderField("Content-Type") == null) {
+            if (status.isSuccessful() &&
+                connection.getResponseBody() == null &&
+                connection.getResponseInputStream() == null &&
+                connection.getHeaderField("Content-Type") == null) {
                 connection.setResponseBody(new Body("{\"ok\":true}".getBytes()));
             }
 


### PR DESCRIPTION
- Fixed the if statement that tries to validate empty content body by also checking the response body stream.

- Make sure that the attachment dictionary will not include content-type if the value is null.

#1280