### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/900

### DIFF
--- a/src/main/java/com/couchbase/lite/DatabaseUpgrade.java
+++ b/src/main/java/com/couchbase/lite/DatabaseUpgrade.java
@@ -326,7 +326,7 @@ public final class DatabaseUpgrade {
                 String digest = blobKey.base64Digest();
 
                 Map<String, Object> att = new HashMap<String, Object>();
-                att.put("type", mimeType);
+                att.put("content_type", mimeType);
                 att.put("digest", digest);
                 att.put("length", length);
                 att.put("revpos", revpos);


### PR DESCRIPTION
[Release 1.2.1] Database upgrades 1.1 -> 1.2.1 not copying "content_type" of attachments during upgrade

- From 1.2.0, field name of content-type is `content_type`, not `type`.