### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/920

### DIFF
--- a/src/main/java/com/couchbase/lite/auth/BasicAuthenticator.java
+++ b/src/main/java/com/couchbase/lite/auth/BasicAuthenticator.java
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2016 Couchbase, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+//
+package com.couchbase.lite.auth;
+
+/**
+ * @deprecated Class name was changed to PasswordAuthorizer. To be consistent with other platforms,
+ * please use `Authenticator AuthenticatorFactory.createBasicAuthenticator(String username, String password)`
+ * to create authenticator for Basic authentication.
+ */
+@Deprecated
+public class BasicAuthenticator extends PasswordAuthorizer {
+    public BasicAuthenticator(String username, String password) {
+        super(username, password);
+    }
+}


### PR DESCRIPTION
Keep BasicAuthenticator for backward compatibility
- some users directly create BasicAuthenticator instance instead of using AuthenticatorFactory. We need to keep this for a while.