### PR TITLE
Fixed #1308 - Encrypted attachments fail to sync

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/replicator/RemoteMultipartRequest.java
@@ -89,7 +89,9 @@ public class RemoteMultipartRequest extends RemoteRequest {
 
     private MultipartBody.Builder createMultipartBody() {
         MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder();
-        multipartBodyBuilder.setType(MultipartBody.FORM);
+
+        // https://en.wikipedia.org/wiki/MIME#Related
+        multipartBodyBuilder.setType(MediaType.parse("multipart/related"));
 
         // JSON body
         byte[] bodyBytes = null;


### PR DESCRIPTION
Two issues to fix:
- Problem: As setting incorrect MimeType (content-type) for multipart document, sync gateway always rejects request with multi-part document. See original ticket.
- Problem: uploadJsonRevision() is used as fallback solution in case Sync Gateway reject multipart request. this code does not handle encrypted attachment