### PR TITLE
Fixed couchbase-lite-android/issues/932: regression bug that Router not set response's Content-Type

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -740,10 +740,10 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
 
         if (contentType != null) {
             Header resHeader = connection.getResHeader();
-            if (resHeader != null && resHeader.get("Content-Type") != null)
+            if (resHeader != null && resHeader.get("Content-Type") == null)
                 resHeader.add("Content-Type", contentType);
             else
-                Log.w(TAG, "Cannot add Content-Type header because getResHeader() returned null");
+                Log.d(TAG, "Cannot add Content-Type header because getResHeader() returned null");
         }
 
         // NOTE: Line 596-607 of CBL_Router.m is not in CBL Java Core


### PR DESCRIPTION
- Fixed the if statement that check if the response header has already had the Content-Type set or not.
- Changed the log level when there is no response header from warning to debug as it normally shoudn't happen.

https://github.com/couchbase/couchbase-lite-android/issues/932