### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/933

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -1474,9 +1474,8 @@ public class Database implements StoreDelegate {
                                                                              List<String> ancestorRevIDs) {
         List<RevisionInternal> history = getRevisionHistory(rev);
         // (this is in reverse order, newest..oldest
-        if (ancestorRevIDs != null && ancestorRevIDs.size() > 0) {
-            int n = history.size();
-            for (int i = 0; i < n; ++i) {
+        if (ancestorRevIDs != null && ancestorRevIDs.size() > 0 && history != null) {
+            for (int i = 0; i < history.size(); ++i) {
                 if (ancestorRevIDs.contains(history.get(i).getRevID())) {
                     history = history.subList(0, i + 1);
                     break;

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -896,7 +896,6 @@ public class SQLiteStore implements Store, EncryptableStore {
         List<RevisionInternal> result;
         try {
             cursor = storageEngine.rawQuery(sql, args);
-
             cursor.moveToNext();
             long lastSequence = 0;
             result = new ArrayList<RevisionInternal>();


### PR DESCRIPTION
NPE and RemoteRequestCompletionBlock in 1.3.0-12

- `history` variable could be `null`.
- It seems Android API 16 returns `null` for `new` instead of throwing `OutOfMemoryException`. It could be different by API versions.