### PR TITLE
Fixed #1339 - Make lower initial heartbeat value for /_changes REST API

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -68,7 +68,7 @@ public class Replication
      */
     public static final String REPLICATOR_DATABASE_NAME = "_replicator";
     public static long DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN = 60; // 60 sec
-    public static int DEFAULT_HEARTBEAT = 300; // 5min (300 sec)
+    public static int DEFAULT_HEARTBEAT = 30; // 30 sec (till v1.2.0 and iOS uses 5min)
 
     /**
      * Options for what metadata to include in document bodies

--- a/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
+++ b/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
@@ -39,11 +39,12 @@ public class CouchbaseLiteHttpClientFactory implements HttpClientFactory {
     private boolean followRedirects = true;
 
     // deprecated
-    public static int DEFAULT_SO_TIMEOUT_SECONDS = 60 * 5;
+    public static int DEFAULT_SO_TIMEOUT_SECONDS = 40; // 40 sec (previously it was 5 min)
+                                                       // heartbeat value 30sec + 10 sec
 
     // OkHttp Default Timeout is 10 sec for all timeout settings
     public static int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 10;
-    public static int DEFAULT_READ_TIMEOUT = DEFAULT_SO_TIMEOUT_SECONDS;
+    public static int DEFAULT_READ_TIMEOUT  = DEFAULT_SO_TIMEOUT_SECONDS;
     public static int DEFAULT_WRITE_TIMEOUT = 10;
 
     /**


### PR DESCRIPTION
- Sync Gateway's minimum value of heartbeat is 25 sec. From sync gateway point of view, any number higher than 25 sec is acceptable. Set default heartbeat value to 30 sec. and set default socket read time out to 40 sec which is 30 sec + 10 sec (extra).