### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-android/issues/884

### DIFF
--- a/src/main/java/com/couchbase/lite/BlobStore.java
+++ b/src/main/java/com/couchbase/lite/BlobStore.java
@@ -480,43 +480,6 @@ public class BlobStore {
         return null;
     }
 
-    /*
-    NO Usages: Should be removed:
-    public boolean storeBlobStream(InputStream inputStream, BlobKey outKey) {
-        File tmp = null;
-        try {
-            tmp = File.createTempFile(TMP_FILE_PREFIX, TMP_FILE_EXTENSION, new File(path));
-            FileOutputStream fos = new FileOutputStream(tmp);
-            byte[] buffer = new byte[65536];
-            int lenRead = inputStream.read(buffer);
-            while (lenRead > 0) {
-                fos.write(buffer, 0, lenRead);
-                lenRead = inputStream.read(buffer);
-            }
-            inputStream.close();
-            fos.close();
-        } catch (IOException e) {
-            Log.e(Log.TAG_DATABASE, "BlobStore: Error writing blob to tmp file", e);
-            return false;
-        }
-
-        BlobKey newKey = keyForBlobFromFile(tmp);
-        outKey.setBytes(newKey.getBytes());
-        String path = getRawPathForKey(outKey);
-        File file = new File(path);
-
-        if (file.canRead()) {
-            // object with this hash already exists, we should delete tmp file and return true
-            tmp.delete();
-            return true;
-        } else {
-            // does not exist, we should rename tmp file to this name
-            tmp.renameTo(file);
-        }
-        return true;
-    }
-    */
-
     public boolean storeBlob(byte[] data, BlobKey outKey) {
         BlobKey newKey = keyForBlob(data);
         outKey.setBytes(newKey.getBytes());
@@ -681,5 +644,9 @@ public class BlobStore {
 
     public SymmetricKey getEncryptionKey() {
         return encryptionKey;
+    }
+
+    public boolean isEncrypted() {
+        return encryptionKey != null;
     }
 }

--- a/src/main/java/com/couchbase/lite/replicator/BlobRequestBody.java
+++ b/src/main/java/com/couchbase/lite/replicator/BlobRequestBody.java
@@ -1,16 +1,16 @@
-/**
- * Copyright (c) 2016 Couchbase, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+//
+// Copyright (c) 2016 Couchbase, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+//
 package com.couchbase.lite.replicator;
 
 import com.couchbase.lite.BlobKey;
@@ -32,7 +32,9 @@ import okio.Source;
 public class BlobRequestBody {
     public static RequestBody create(final MediaType contentType,
                                      final BlobStore blobStore,
-                                     final BlobKey blobKey) {
+                                     final BlobKey blobKey,
+                                     final long declaredLength,
+                                     final boolean syncGateway) {
         if (blobStore == null) throw new NullPointerException("blobStore == null");
         if (blobKey == null) throw new NullPointerException("blobKey == null");
 
@@ -40,6 +42,36 @@ public class BlobRequestBody {
             @Override
             public MediaType contentType() {
                 return contentType;
+            }
+
+
+            /**
+             * OkHttp use chunked transfer if content-length is unknown. And CouchDB 1.6.1 can not
+             * handle chunked transer with multipart doc, then CouchDB disconnect .
+             * To send non-chunked transfer with multipart document by OkHttp, the client needs
+             * to specify content-length.
+             * Sync Gateway can accept chunked transfer
+             */
+            @Override
+            public long contentLength() throws IOException {
+                // Sync Gateway
+                if (syncGateway) {
+                    return super.contentLength();
+                }
+                // CouchDB or Couchbase Lite
+                else {
+                    // encrypted
+                    if (blobStore.isEncrypted()) {
+                        if (declaredLength > 0)
+                            return declaredLength;
+                        else
+                            return super.contentLength();
+                    } else {
+                        // gzipped or non-encrypted content
+                        // NOTE: gzipped: CBL Java sends gzipped contents without decode.
+                        return blobStore.getSizeOfBlob(blobKey);
+                    }
+                }
             }
 
             @Override

--- a/src/main/java/com/couchbase/lite/replicator/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/replicator/RemoteMultipartRequest.java
@@ -36,6 +36,7 @@ public class RemoteMultipartRequest extends RemoteRequest {
     ////////////////////////////////////////////////////////////
     private Map<String, Object> attachments;
     private Database db;
+    private boolean syncGateway;
 
     ////////////////////////////////////////////////////////////
     // Constructors
@@ -45,6 +46,7 @@ public class RemoteMultipartRequest extends RemoteRequest {
             HttpClientFactory clientFactory,
             String method,
             URL url,
+            boolean syncGateway,
             boolean cancelable,
             Map<String, ?> body,
             Map<String, Object> attachments,
@@ -54,6 +56,7 @@ public class RemoteMultipartRequest extends RemoteRequest {
         super(clientFactory, method, url, cancelable, body, requestHeaders, onCompletion);
         this.attachments = attachments;
         this.db = db;
+        this.syncGateway = syncGateway;
     }
 
     ////////////////////////////////////////////////////////////
@@ -148,8 +151,13 @@ public class RemoteMultipartRequest extends RemoteRequest {
                 if (contentEncoding != null)
                     builder.add("Content-Encoding", contentEncoding);
 
+                // check content-length which is stored in attachments table.
+                long declaredLength = 0;
+                if(attachment.containsKey("length"))
+                    declaredLength = ((Integer)attachment.get("length")).longValue();
+
                 MediaType type = MediaType.parse(contentType);
-                RequestBody body = BlobRequestBody.create(type, blobStore, blobKey);
+                RequestBody body = BlobRequestBody.create(type, blobStore, blobKey, declaredLength, syncGateway);
                 multipartBodyBuilder.addPart(builder.build(), body);
             }
         }

--- a/src/main/java/com/couchbase/lite/replicator/RemoteRequestRetry.java
+++ b/src/main/java/com/couchbase/lite/replicator/RemoteRequestRetry.java
@@ -84,6 +84,7 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
     private Throwable requestThrowable;
     private BlockingQueue<Future> pendingRequests;
     Map<Future, CancellableRunnable> runnables = new HashMap<Future, CancellableRunnable>();
+    private boolean syncGateway = true;
     private boolean cancelable = true;
     // if true, we wont log any 404 errors (useful when getting remote checkpoint doc)
     private boolean dontLog404;
@@ -103,6 +104,7 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
                               HttpClientFactory clientFactory,
                               String method,
                               URL url,
+                              boolean syncGateway,
                               boolean cancelable,
                               Map<String, Object> body,
                               Map<String, Object> attachments,
@@ -114,6 +116,7 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
         this.clientFactory = clientFactory;
         this.method = method;
         this.url = url;
+        this.syncGateway = syncGateway;
         this.cancelable = cancelable;
         this.body = body;
         this.attachments = attachments;
@@ -247,6 +250,7 @@ public class RemoteRequestRetry<T> implements CustomFuture<T> {
                         clientFactory,
                         method,
                         url,
+                        syncGateway,
                         cancelable,
                         body,
                         attachments,

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -82,6 +82,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     public static final String CHANNELS_QUERY_PARAM = "channels";
     public static final int EXECUTOR_THREAD_POOL_SIZE = 5;
     public static final int MIN_EXECUTOR_THREAD_POOL_SIZE = 2;
+    public static final String SYNC_GATEWAY_PREFIX = "Couchbase Sync Gateway/";
 
     private static int lastSessionID = 0;
     public static int RETRY_DELAY_SECONDS = 60; // #define kRetryDelay 60.0 in CBL_Replicator.m
@@ -677,6 +678,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 clientFactory,
                 method,
                 url,
+                serverIsSyncGateway(),
                 cancelable,
                 body,
                 null,
@@ -723,6 +725,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 clientFactory,
                 method,
                 url,
+                serverIsSyncGateway(),
                 true,
                 body,
                 attachments,
@@ -753,6 +756,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                     clientFactory,
                     method,
                     url,
+                    serverIsSyncGateway(),
                     true,
                     body,
                     null,
@@ -1521,14 +1525,18 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     }
 
     @InterfaceAudience.Private
+    protected boolean serverIsSyncGateway() {
+        return serverType == null || !serverType.startsWith(SYNC_GATEWAY_PREFIX) ? false : true;
+    }
+
+    @InterfaceAudience.Private
     protected static boolean serverIsSyncGatewayVersion(String serverName, String minVersion) {
-        String prefix = "Couchbase Sync Gateway/";
         if (serverName == null) {
             return false;
         } else {
-            if (serverName.startsWith(prefix)) {
-                String versionString = serverName.substring(prefix.length());
-                // NOTE: If version number is higher than 10.xx, this comprison does not work eg. "10.0" < "2.0"
+            if (serverName.startsWith(SYNC_GATEWAY_PREFIX)) {
+                String versionString = serverName.substring(SYNC_GATEWAY_PREFIX.length());
+                // NOTE: If version number is higher than 10.xx, this comparison does not work eg. "10.0" < "2.0"
                 return versionString.compareTo(minVersion) >= 0;
             }
         }


### PR DESCRIPTION
[CouchDB 1.6.1] ver. 1.2.1 has Exception uploading multipart request org.apache.http.client.ClientProtocolException

- Problem: OkHttp use chunked transfer for multipart document request if content-length is unknown. And CouchDB 1.6.1 disconnects connection for it.
- Solution: Needs to return actual content-length if server is CouchDB. SyncGateway can handle chunked transfer.