### PR TITLE
Fixed #1352 - Crash when running with SQLCipher

### DIFF
--- a/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
@@ -44,6 +44,14 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
 
     abstract protected String getICUDatabasePath();
 
+    /**
+     * Gets the connection pool size when in WAL mode.
+     *
+     * Maximum number of database connections opened and managed by framework layer
+     * to handle queries on each database when using Write-Ahead Logging.
+     */
+    abstract protected int getWALConnectionPoolSize();
+
     @Override
     public boolean open(String path, SymmetricKey encryptionKey) throws SQLException {
         if(database != null && database.isOpen())
@@ -61,6 +69,7 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
             SQLiteDatabase.setDatabasePlatformSupport(getDatabasePlatformSupport());
             database = SQLiteDatabase.openDatabase(path, null,
                     SQLiteDatabase.CREATE_IF_NECESSARY | SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING,
+                    getWALConnectionPoolSize(),
                     null, new ConnectionListener());
             Log.v(Log.TAG_DATABASE, "%s: Opened Android sqlite db", this);
         } catch(SQLiteDatabaseCorruptException e) {

--- a/vendor/sqlite/src/java/com/couchbase/lite/internal/database/sqlite/SQLiteDatabase.java
+++ b/vendor/sqlite/src/java/com/couchbase/lite/internal/database/sqlite/SQLiteDatabase.java
@@ -246,11 +246,12 @@ public final class SQLiteDatabase extends SQLiteClosable {
         SQLiteNativeLibrary.load();
     }
 
-    private SQLiteDatabase(String path, int openFlags, CursorFactory cursorFactory,
-            DatabaseErrorHandler errorHandler, com.couchbase.lite.internal.database.sqlite.SQLiteConnectionListener connectionListener) {
+    private SQLiteDatabase(String path, int openFlags, int walConnectionPoolSize,
+                           CursorFactory cursorFactory,
+                           DatabaseErrorHandler errorHandler, com.couchbase.lite.internal.database.sqlite.SQLiteConnectionListener connectionListener) {
         mCursorFactory = cursorFactory;
         mErrorHandler = errorHandler;
-        mConfigurationLocked = new com.couchbase.lite.internal.database.sqlite.SQLiteDatabaseConfiguration(path, openFlags);
+        mConfigurationLocked = new com.couchbase.lite.internal.database.sqlite.SQLiteDatabaseConfiguration(path, openFlags, walConnectionPoolSize);
         mConnectionListener = connectionListener;
     }
 
@@ -667,8 +668,8 @@ public final class SQLiteDatabase extends SQLiteClosable {
      * @throws com.couchbase.lite.internal.database.sqlite.exception.SQLiteException if the database cannot be opened
      */
     public static SQLiteDatabase openDatabase(String path, CursorFactory factory, int flags,
-            DatabaseErrorHandler errorHandler) {
-        return openDatabase(path, factory, flags, errorHandler, null);
+                                              DatabaseErrorHandler errorHandler) {
+        return openDatabase(path, factory, flags, 0, errorHandler, null);
     }
 
     /**
@@ -682,14 +683,18 @@ public final class SQLiteDatabase extends SQLiteClosable {
      * @param factory an optional factory class that is called to instantiate a
      *            cursor when query is called, or null for default
      * @param flags to control database access mode
+     * @param walConnectionPoolSize maximum connection pool size
      * @param errorHandler the {@link DatabaseErrorHandler} obj to be used to handle corruption
      * when sqlite reports database corruption
      * @return the newly opened database
      * @throws com.couchbase.lite.internal.database.sqlite.exception.SQLiteException if the database cannot be opened
      */
-    public static SQLiteDatabase openDatabase(String path, CursorFactory factory, int flags,
-            DatabaseErrorHandler errorHandler, com.couchbase.lite.internal.database.sqlite.SQLiteConnectionListener connectionListener) {
-        SQLiteDatabase db = new SQLiteDatabase(path, flags, factory, errorHandler, connectionListener);
+    public static SQLiteDatabase openDatabase(
+            String path, CursorFactory factory, int flags,
+            int walConnectionPoolSize,
+            DatabaseErrorHandler errorHandler,
+            com.couchbase.lite.internal.database.sqlite.SQLiteConnectionListener connectionListener) {
+        SQLiteDatabase db = new SQLiteDatabase(path, flags, walConnectionPoolSize, factory, errorHandler, connectionListener);
         db.open();
         return db;
     }

--- a/vendor/sqlite/src/java/com/couchbase/lite/internal/database/sqlite/SQLiteDatabaseConfiguration.java
+++ b/vendor/sqlite/src/java/com/couchbase/lite/internal/database/sqlite/SQLiteDatabaseConfiguration.java
@@ -88,13 +88,20 @@ public final class SQLiteDatabaseConfiguration {
     public boolean foreignKeyConstraintsEnabled;
 
     /**
+     * Maximum number of database connections opened and managed by framework layer
+     * to handle queries on each database when using Write-Ahead Logging.
+     */
+    public int walConnectionPoolSize = 0;
+
+    /**
      * Creates a database configuration with the required parameters for opening a
      * database and default values for all other parameters.
      *
      * @param path The database path.
      * @param openFlags Open flags for the database, such as {@link SQLiteDatabase#OPEN_READWRITE}.
+     * @param walConnectionPoolSize
      */
-    public SQLiteDatabaseConfiguration(String path, int openFlags) {
+    public SQLiteDatabaseConfiguration(String path, int openFlags, int walConnectionPoolSize) {
         if (path == null) {
             throw new IllegalArgumentException("path must not be null.");
         }
@@ -102,6 +109,7 @@ public final class SQLiteDatabaseConfiguration {
         this.path = path;
         label = stripPathForLogs(path);
         this.openFlags = openFlags;
+        this.walConnectionPoolSize = walConnectionPoolSize;
 
         // Set default values for optional parameters.
         maxSqlCacheSize = 25;


### PR DESCRIPTION
- Multiple SQLite connections with SQLCipher could cause crashes in the native codes.
- We decided to use single connection with Android API version 20 or lower, And use multiple connections with API 21 or higher.