### PR TITLE
Fixed gzipped attachment not returning gzipped content.

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/AttachmentInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/AttachmentInternal.java
@@ -211,6 +211,8 @@ public class AttachmentInternal {
         return new ByteArrayInputStream(getContent());
     }
 
+    public InputStream getEncodedContentInputStream() { return new ByteArrayInputStream(getEncodedContent()); }
+
     public URL getContentURL() throws MalformedURLException {
         String path = database.getAttachmentStore().getBlobPathForKey(blobKey);
         return path != null ? new File(path).toURI().toURL() : null;

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -2051,10 +2051,12 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             if (acceptEncoding != null && acceptEncoding.contains("gzip") &&
                     attachment.getEncoding() == AttachmentInternal.AttachmentEncoding.AttachmentEncodingGZIP) {
                 connection.getResHeader().add("Content-Encoding", "gzip");
+                connection.setResponseInputStream(attachment.getEncodedContentInputStream());
             }
-
+            else {
+                connection.setResponseInputStream(attachment.getContentInputStream());
+            }
             dontOverwriteBody = true;
-            connection.setResponseInputStream(attachment.getContentInputStream());
             return new Status(Status.OK);
 
         } catch (CouchbaseLiteException e) {


### PR DESCRIPTION
With couchbase lite android v1.3.0, getting a gzipped attachment fails. Using httpie on the command line (http --verbose GET http://attachment_url) shows that the attachment response is encoded with "content-encoding: gzip" but cannot be decoded.
Router.java is setting "content-encoding:gzip", but using getContentInputStream() which returns decompressed content using Utils.decompressByGzip(data). 
The mismatch between "content-encoding:gzip" and decompressed content causes an error. Added getEncodedContentInputStream() to return gzipped content. Also extended conditional to make sure content-encoding and content match.