### PR TITLE
Fixed #1386 and andriod #939 : POST /_replicate to start multiple replicators and threading issues

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -2417,9 +2417,13 @@ public class Database implements StoreDelegate {
 
     protected Replication findActiveReplicator(Replication replicator) {
         synchronized (activeReplicators) {
-            for (Replication active : activeReplicators) {
-                if (active.equals(replicator) && active.isRunning())
-                    return active;
+            String remoteCheckpointDocID = replicator.remoteCheckpointDocID();
+            if (remoteCheckpointDocID == null)
+                return null;
+
+            for (Replication r : activeReplicators) {
+                if (remoteCheckpointDocID.equals(r.remoteCheckpointDocID()) && r.isRunning())
+                    return r;
             }
         }
         return null;

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -2415,40 +2415,23 @@ public class Database implements StoreDelegate {
 
     // Database+Replication
 
-    protected Replication getActiveReplicator(URL remote, boolean push) {
+    protected Replication findActiveReplicator(Replication replicator) {
         synchronized (activeReplicators) {
-            try {
-                java.net.URI remoteUri = remote.toURI();
-                for (Replication replicator : activeReplicators) {
-                    if (replicator.getRemoteUrl().toURI().equals(remoteUri) &&
-                            replicator.isPull() == !push && replicator.isRunning())
-                        return replicator;
-                }
-            } catch (java.net.URISyntaxException uriException) {
-                // Not possible since it would not be an active replicator.
-                // However, until we refactor everything to use java.net,
-                // I'm not sure we have a choice but to swallow this.
-                Log.e(Log.TAG_DATABASE, "Active replicator found with invalid URI", uriException);
+            for (Replication active : activeReplicators) {
+                if (active.equals(replicator) && active.isRunning())
+                    return active;
             }
         }
         return null;
     }
 
-    protected Replication getReplicator(URL remote,
-                                        HttpClientFactory httpClientFactory,
-                                        boolean push,
-                                        boolean continuous) {
-        Replication result = getActiveReplicator(remote, push);
-        if (result != null) {
-            return result;
-        }
-        if (push) {
-            result = new Replication(this, remote, Replication.Direction.PUSH, httpClientFactory);
-        } else {
-            result = new Replication(this, remote, Replication.Direction.PULL, httpClientFactory);
-        }
-        result.setContinuous(continuous);
-        return result;
+    protected Replication createReplicator(URL remote, boolean push, HttpClientFactory factory) {
+        Replication replicator;
+        if (push)
+            replicator = new Replication(this, remote, Replication.Direction.PUSH, factory);
+        else
+            replicator = new Replication(this, remote, Replication.Direction.PULL, factory);
+        return replicator;
     }
 
     // Database+LocalDocs

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -1047,10 +1047,10 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     @Override
     public String toString() {
-        if (str == null) {
+        if (str == null || str.contains("unknown")) {
             String maskedRemote = "unknown";
             if (remote != null)
-                remote.toExternalForm();
+                maskedRemote = remote.toExternalForm();
             maskedRemote = maskedRemote.replaceAll("://.*:.*@", "://---:---@");
             String type = isPull() ? "pull" : "push";
             String replicationIdentifier = Utils.shortenString(remoteCheckpointDocID(), 5);

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -464,7 +464,8 @@ public class Replication
     /**
      * Following two methods for temporary methods instead of CBL_ReplicatorSettings implementation.
      */
-    protected String remoteCheckpointDocID() {
+    @InterfaceAudience.Private
+    public String remoteCheckpointDocID() {
         return replicationInternal.remoteCheckpointDocID();
     }
 
@@ -937,20 +938,5 @@ public class Replication
     @Override
     public String toString() {
         return "Replication{" + remote + ", " + (isPull() ? "pull" : "push") + '}';
-    }
-
-    @Override
-    public int hashCode() {
-        return replicationInternal.remoteCheckpointDocID().hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof Replication) {
-            Replication replication = (Replication)obj;
-            return this.replicationInternal.remoteCheckpointDocID().equals(
-                    replication.replicationInternal.remoteCheckpointDocID());
-        }
-        return false;
     }
 }

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -938,4 +938,19 @@ public class Replication
     public String toString() {
         return "Replication{" + remote + ", " + (isPull() ? "pull" : "push") + '}';
     }
+
+    @Override
+    public int hashCode() {
+        return replicationInternal.remoteCheckpointDocID().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Replication) {
+            Replication replication = (Replication)obj;
+            return this.replicationInternal.remoteCheckpointDocID().equals(
+                    replication.replicationInternal.remoteCheckpointDocID());
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -400,6 +400,13 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         // Refer to: http://wiki.apache.org/couchdb/Complete_HTTP_API_Reference
 
         String method = connection.getRequestMethod();
+
+        // Support CORS Preflight requests:
+        if ("OPTIONS".equals(method)) {
+            sendResponseCodeAndFinish(Status.OK);
+            return;
+        }
+
         // We're going to map the request into a method call using reflection based on the method and path.
         // Accumulate the method name into the string 'message':
         if ("HEAD".equals(method)) {
@@ -410,13 +417,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         // First interpret the components of the request:
         List<String> path = splitPath(connection.getURL());
         if (path == null) {
-            connection.setResponseCode(Status.BAD_REQUEST);
-            try {
-                connection.getResponseOutputStream().close();
-            } catch (IOException e) {
-                Log.e(TAG, "Error closing empty output stream");
-            }
-            sendResponse();
+            sendResponseCodeAndFinish(Status.BAD_REQUEST);
             return;
         }
 
@@ -439,25 +440,14 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
 
                     ByteArrayInputStream bais = new ByteArrayInputStream(connection.getResponseBody().getJson());
                     connection.setResponseInputStream(bais);
-                    connection.setResponseCode(Status.BAD_REQUEST);
-                    try {
-                        connection.getResponseOutputStream().close();
-                    } catch (IOException e) {
-                        Log.e(TAG, "Error closing empty output stream");
-                    }
-                    sendResponse();
+
+                    sendResponseCodeAndFinish(Status.BAD_REQUEST);
                     return;
                 } else {
                     boolean mustExist = false;
                     db = manager.getDatabase(dbName, mustExist); // NOTE: synchronized
                     if (db == null) {
-                        connection.setResponseCode(Status.BAD_REQUEST);
-                        try {
-                            connection.getResponseOutputStream().close();
-                        } catch (IOException e) {
-                            Log.e(TAG, "Error closing empty output stream");
-                        }
-                        sendResponse();
+                        sendResponseCodeAndFinish(Status.BAD_REQUEST);
                         return;
                     }
 
@@ -473,39 +463,21 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             // Make sure database exists, then interpret doc name:
             Status status = openDB();
             if (!status.isSuccessful()) {
-                connection.setResponseCode(status.getCode());
-                try {
-                    connection.getResponseOutputStream().close();
-                } catch (IOException e) {
-                    Log.e(TAG, "Error closing empty output stream");
-                }
-                sendResponse();
+                sendResponseCodeAndFinish(status.getCode());
                 return;
             }
             String name = path.get(1);
             if (!name.startsWith("_")) {
                 // Regular document
                 if (!Document.isValidDocumentId(name)) {
-                    connection.setResponseCode(Status.BAD_REQUEST);
-                    try {
-                        connection.getResponseOutputStream().close();
-                    } catch (IOException e) {
-                        Log.e(TAG, "Error closing empty output stream");
-                    }
-                    sendResponse();
+                    sendResponseCodeAndFinish(Status.BAD_REQUEST);
                     return;
                 }
                 docID = name;
             } else if ("_design".equals(name) || "_local".equals(name)) {
                 // "_design/____" and "_local/____" are document names
                 if (pathLen <= 2) {
-                    connection.setResponseCode(Status.NOT_FOUND);
-                    try {
-                        connection.getResponseOutputStream().close();
-                    } catch (IOException e) {
-                        Log.e(TAG, "Error closing empty output stream");
-                    }
-                    sendResponse();
+                    sendResponseCodeAndFinish(Status.NOT_FOUND);
                     return;
                 }
                 docID = name + '/' + path.get(2);
@@ -767,6 +739,16 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         connection.getResHeader().add("Location", location);
     }
 
+    private void sendResponseCodeAndFinish(int code) {
+        connection.setResponseCode(code);
+        try {
+            connection.getResponseOutputStream().close();
+        } catch (IOException e) {
+            Log.e(TAG, "Error closing empty output stream");
+        }
+        sendResponse();
+    }
+
     /**
      * SERVER REQUESTS: *
      */
@@ -800,89 +782,82 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     }
 
     public Status do_POST_replicate(Database _db, String _docID, String _attachmentName) {
+        synchronized (manager) {
+            Replication replicator;
 
-        Replication replicator;
+            // Extract the parameters from the JSON request body:
+            // http://wiki.apache.org/couchdb/Replication
+            Map<String, Object> body = null;
+            try {
+                body = getBodyAsDictionary();
+                replicator = manager.getReplicator(body);
+            } catch (CouchbaseLiteException e) {
+                Map<String, Object> result = new HashMap<String, Object>();
+                result.put("error", e.toString());
+                connection.setResponseBody(new Body(result));
+                return e.getCBLStatus();
+            }
 
-        // Extract the parameters from the JSON request body:
-        // http://wiki.apache.org/couchdb/Replication
-        Map<String, Object> body = null;
-        try {
-            body = getBodyAsDictionary();
-        } catch (CouchbaseLiteException e) {
-            return e.getCBLStatus();
-        }
+            Boolean cancelBoolean = (Boolean) body.get("cancel");
+            boolean cancel = (cancelBoolean != null && cancelBoolean.booleanValue());
 
-        try {
-            // NOTE: replicator instance is created per request. not access shared instances
-            replicator = manager.getReplicator(body);
-        } catch (CouchbaseLiteException e) {
-            Map<String, Object> result = new HashMap<String, Object>();
-            result.put("error", e.toString());
-            connection.setResponseBody(new Body(result));
-            return e.getCBLStatus();
-        }
-
-        Boolean cancelBoolean = (Boolean) body.get("cancel");
-        boolean cancel = (cancelBoolean != null && cancelBoolean.booleanValue());
-
-        if (!cancel) {
-
-            if (!replicator.isRunning()) {
-
-                final CountDownLatch replicationStarted = new CountDownLatch(1);
-                replicator.addChangeListener(new Replication.ChangeListener() {
-                    @Override
-                    public void changed(Replication.ChangeEvent event) {
-                        if (event.getTransition() != null &&
-                                event.getTransition().getDestination() == ReplicationState.RUNNING) {
-                            replicationStarted.countDown();
-                        }
-                    }
-                });
-
-                if (!replicator.isContinuous()) {
+            if (!cancel) {
+                if (!replicator.isRunning()) {
+                    final CountDownLatch replicationStarted = new CountDownLatch(1);
                     replicator.addChangeListener(new Replication.ChangeListener() {
                         @Override
                         public void changed(Replication.ChangeEvent event) {
                             if (event.getTransition() != null &&
-                                    event.getTransition().getDestination() == ReplicationState.STOPPED) {
-                                Status status = new Status(Status.OK);
-                                status = sendResponseHeaders(status);
-                                connection.setResponseCode(status.getCode());
-                                Map<String, Object> result = new HashMap<String, Object>();
-                                result.put("session_id", event.getSource().getSessionID());
-                                connection.setResponseBody(new Body(result));
-
-                                setResponse();
-                                sendResponse();
+                                    event.getTransition().getDestination() == ReplicationState.RUNNING) {
+                                replicationStarted.countDown();
                             }
                         }
                     });
+
+                    if (!replicator.isContinuous()) {
+                        replicator.addChangeListener(new Replication.ChangeListener() {
+                            @Override
+                            public void changed(Replication.ChangeEvent event) {
+                                if (event.getTransition() != null &&
+                                        event.getTransition().getDestination() == ReplicationState.STOPPED) {
+                                    Status status = new Status(Status.OK);
+                                    status = sendResponseHeaders(status);
+                                    connection.setResponseCode(status.getCode());
+
+                                    Map<String, Object> result = new HashMap<String, Object>();
+                                    result.put("session_id", event.getSource().getSessionID());
+                                    connection.setResponseBody(new Body(result));
+
+                                    setResponse();
+                                    sendResponse();
+                                }
+                            }
+                        });
+                    }
+
+                    replicator.start();
+
+                    // wait for replication to start, otherwise replicator.getSessionId() will return null
+                    try {
+                        replicationStarted.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
 
-                replicator.start();
-
-                // wait for replication to start, otherwise replicator.getSessionId() will return null
-                try {
-                    replicationStarted.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
+                if (replicator.isContinuous()) {
+                    Map<String, Object> result = new HashMap<String, Object>();
+                    result.put("session_id", replicator.getSessionID());
+                    connection.setResponseBody(new Body(result));
+                    return new Status(Status.OK);
+                } else {
+                    return new Status(0);
                 }
-
-            }
-
-            if (replicator.isContinuous()) {
-                Map<String, Object> result = new HashMap<String, Object>();
-                result.put("session_id", replicator.getSessionID());
-                connection.setResponseBody(new Body(result));
-                return new Status(Status.OK);
             } else {
-                return new Status(0);
+                // Cancel replication:
+                replicator.stop();
+                return new Status(Status.OK);
             }
-        } else {
-            // Cancel replication:
-            replicator.stop();
-            return new Status(Status.OK);
         }
     }
 


### PR DESCRIPTION
- Fixed creating multiple replicators of the same properties from sending
   multiple simultaneously POST /_replicate requests. The fix is synchronizing
   manager object in Router.do_POST_replicate() method.
   Ref: https://github.com/couchbase/couchbase-lite-android/issues/939

- Fixed not being able to create different replicators that have the same URL
   and type but different other properties. The fix is to ensure that
   Manager.getReplicator() searches a new create replicator against
   the current active replicators correctly. Ref: #1386

- [PLUS] In Router, extracted send response code into its own method
   called `sendResponseCodeAndFinish()` to avoid writing this same
   piece of codes several time.

- [PLUS to Router] Added CORS preflight /OPTIONS requests support to
   allow to test the listener with Web App.