### PR TITLE
Fixed #1379: Fix cast attachment length

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/RemoteMultipartRequest.java
+++ b/src/main/java/com/couchbase/lite/replicator/RemoteMultipartRequest.java
@@ -154,7 +154,7 @@ public class RemoteMultipartRequest extends RemoteRequest {
                 // check content-length which is stored in attachments table.
                 long declaredLength = 0;
                 if(attachment.containsKey("length"))
-                    declaredLength = ((Integer)attachment.get("length")).longValue();
+                    declaredLength = ((Number)attachment.get("length")).longValue();
 
                 MediaType type = MediaType.parse(contentType);
                 RequestBody body = BlobRequestBody.create(type, blobStore, blobKey, declaredLength, syncGateway);

--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -132,10 +132,10 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
             Map<String, Object> attachment = (Map<String, Object>) attachments.get(attachmentName);
             int length = 0;
             if (attachment.containsKey("length")) {
-                length = ((Integer) attachment.get("length")).intValue();
+                length = ((Number)attachment.get("length")).intValue();
             }
             if (attachment.containsKey("encoded_length")) {
-                length = ((Integer) attachment.get("encoded_length")).intValue();
+                length = ((Number)attachment.get("encoded_length")).intValue();
             }
             if (attachment.containsKey("follows") &&
                     ((Boolean) attachment.get("follows")).booleanValue() == true) {


### PR DESCRIPTION
From #1379, jackson sometimes deserializes number into float instead of int. Instead of casting the value into Integer directly, cast it to Number and then get the integer / long value from the Number object. This changes make the code consistent with the other places in couchbase-java-core when getting the attachment length.