### PR TITLE
updated getPendingDocumentIDs() to return non-cached version while offline

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -483,6 +483,9 @@ public class Replication
              *   return pendingDocIDs;
             */
 
+            if (isPull())
+                return pendingDocIDs;
+            
             final CountDownLatch latch = new CountDownLatch(1);
             db.getManager().getWorkExecutor().submit(new Runnable() {
                 @Override

--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -470,8 +470,18 @@ public class Replication
 
     public Set<String> getPendingDocumentIDs() {
         synchronized (lockPendingDocIDs) {
-            if (isPull() || (isRunning() && pendingDocIDs != null))
-                return pendingDocIDs;
+
+            /** 
+             * Bug causing code                
+             * Expected Functionality:
+             *      While offline, I expect the return value of this method to reflect
+             *      the number of pendingDocIDs inline with database mutations 
+             * Actual Behavior:
+             *      The commented out lines below, output a cached value for pendingDocIDs 
+             *
+             * if (isPull() || (isRunning() && pendingDocIDs != null))
+             *   return pendingDocIDs;
+            */
 
             final CountDownLatch latch = new CountDownLatch(1);
             db.getManager().getWorkExecutor().submit(new Runnable() {


### PR DESCRIPTION
This fixes a bug where the pendingDocIDs returned is incorrect. I've maintained a check for isPull as requested. I know you wish to port changed from CBL iOS (https://github.com/couchbase/couchbase-lite-ios/blob/master/Source/API/CBLReplication.m#L445-L451) but can we at least have this change accepted in the meantime because it does fix the issue 