### PR TITLE
Fixed #1408 : Update Sync Protocol Version to 1.3

### DIFF
--- a/src/main/java/com/couchbase/lite/support/Version.java
+++ b/src/main/java/com/couchbase/lite/support/Version.java
@@ -18,7 +18,7 @@ import com.couchbase.lite.util.Log;
 import java.util.Locale;
 
 public class Version {
-    public static final String SYNC_PROTOCOL_VERSION = "1.2";
+    public static final String SYNC_PROTOCOL_VERSION = "1.3";
     public static final String VERSION;
 
     private static final String VERSION_NAME="%VERSION_NAME%";  // replaced during build process


### PR DESCRIPTION
As we have a new OIDC authentication, bumped the sync version to 1.3.