### PR TITLE
Fixed #1421 Allow lastError to be cleared from outside

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/Replication.java
+++ b/src/main/java/com/couchbase/lite/replicator/Replication.java
@@ -460,6 +460,12 @@ public class Replication
     protected void setLastError(Throwable lastError) {
         this.lastError = lastError;
     }
+    /**
+     * Clear lastError from outside once the error is handled
+     */
+    public void clearLastError() {
+        this.lastError = null;
+    }
 
     /**
      * Following two methods for temporary methods instead of CBL_ReplicatorSettings implementation.


### PR DESCRIPTION
Issue #1421 
Allow lastError to be cleared from outside once the error is handled.