### PR TITLE
fix default changes timeout value

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -84,7 +84,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     public static final String TAG = Log.TAG_ROUTER;
 
     private static final long MIN_CHANGES_HEARTBEAT = 5000;    // 5 seconds
-    private static final long DEFAULT_CHANGES_TIMEOUT = 10000; // 60 seconds
+    private static final long DEFAULT_CHANGES_TIMEOUT = 60000; // 60 seconds
 
     private static final String CONTENT_TYPE_JSON = "application/json";
 


### PR DESCRIPTION
I believe the DEFAULT_CHANGES_TIMEOUT was supposed to be 60 seconds as mentioned in the f288ed8 for 1.3.1 and in the commit message.