### PR TITLE
Fixed #1428 - DSQLiteStore.winningRevIDOfDocNumericID always returns outIsConflict as false

### DIFF
--- a/src/main/java/com/couchbase/lite/DocumentChange.java
+++ b/src/main/java/com/couchbase/lite/DocumentChange.java
@@ -22,6 +22,10 @@ import java.util.Locale;
 /**
  * Provides details about a Document change.
  */
+/**
+ * Identifies a change to a database, that is, a newly added document revision.
+ * The Database.ChangeEvent contains an List<DocumentChange> in "changes".
+ */
 public class DocumentChange {
     private RevisionInternal addedRevision;
     private String documentID;
@@ -50,26 +54,43 @@ public class DocumentChange {
         this.documentID = docID;
     }
 
+    /**
+     *  The ID of the document that changed.
+     */
     @InterfaceAudience.Public
     public String getDocumentId() {
         return documentID;
     }
 
+    /**
+     * The ID of the newly-added revision. A nil value means the document was purged.
+     */
     @InterfaceAudience.Public
     public String getRevisionId() {
         return addedRevision != null ? addedRevision.getRevID() : null;
     }
 
+    /**
+     * Is the new revision the document's current (default, winning) one?
+     * If not, there's a conflict.
+     */
     @InterfaceAudience.Public
     public boolean isCurrentRevision() {
-        return winningRevisionID != null && addedRevision != null && addedRevision.getRevID().equals(winningRevisionID);
+        return winningRevisionID != null && addedRevision != null &&
+                addedRevision.getRevID().equals(winningRevisionID);
     }
 
+    /**
+     * YES if the document is in conflict. (The conflict might pre-date this change.)
+     */
     @InterfaceAudience.Public
     public boolean isConflict() {
         return isConflict;
     }
 
+    /**
+     * The remote database URL that this change was pulled from, if any.
+     */
     @InterfaceAudience.Public
     public URL getSource() {
         return source;

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -1446,7 +1446,7 @@ public class SQLiteStore implements Store, EncryptableStore {
             }
 
             AtomicBoolean oldWinnerWasDeletion = new AtomicBoolean(false);
-            AtomicBoolean wasConflicted = new AtomicBoolean(false);
+            AtomicBoolean wasConflicted = new AtomicBoolean(true);
             String oldWinningRevID = null;
             if (!isNewDoc.get()) {
                 // Look up which rev is the winner, before this insertion

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -1446,7 +1446,7 @@ public class SQLiteStore implements Store, EncryptableStore {
             }
 
             AtomicBoolean oldWinnerWasDeletion = new AtomicBoolean(false);
-            AtomicBoolean wasConflicted = new AtomicBoolean(true);
+            AtomicBoolean wasConflicted = new AtomicBoolean(false);
             String oldWinningRevID = null;
             if (!isNewDoc.get()) {
                 // Look up which rev is the winner, before this insertion
@@ -2255,7 +2255,7 @@ public class SQLiteStore implements Store, EncryptableStore {
                 " WHERE doc_id=? and current=1" +
                 " ORDER BY deleted asc, revid desc LIMIT ?";
 
-        long limit = (outIsConflict != null && outIsConflict.get()) ? 2 : 1;
+        long limit = outIsConflict != null ? 2 : 1;
         String[] args = {Long.toString(docNumericId), Long.toString(limit)};
         String revID = null;
         try {


### PR DESCRIPTION
…icted when using ForestDB

Problem:
Following method does not update outIsConflict if it is set false.
```
    protected String winningRevIDOfDocNumericID(long docNumericId,
                                                AtomicBoolean outIsDeleted,
                                                AtomicBoolean outIsConflict) // optional
```

When following code is called, wasConflicted is always false.
```
            // There may be a conflict if (a) the document was already in conflict, or
            // (b) a conflict is created by adding a non-deletion child of a non-winning rev.
            inConflict = wasConflicted.get() ||
                    (!deleting &&
                            prevRevID != null &&
                            oldWinningRevID != null &&
                            !prevRevID.equals(oldWinningRevID));
```