### PR TITLE
Fixed Android Issue 1009 - attempt to re-open an already-closed object

### DIFF
--- a/src/main/java/com/couchbase/lite/CouchbaseLiteRuntimeException.java
+++ b/src/main/java/com/couchbase/lite/CouchbaseLiteRuntimeException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016 Couchbase, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.couchbase.lite;
+
+/**
+ * Created by hideki on 9/30/16.
+ */
+public class CouchbaseLiteRuntimeException extends RuntimeException {
+    public CouchbaseLiteRuntimeException() {
+    }
+
+    public CouchbaseLiteRuntimeException(String error) {
+        super(error);
+    }
+
+    public CouchbaseLiteRuntimeException(String error, Throwable cause) {
+        super(error, cause);
+    }
+}

--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -102,7 +102,6 @@ public class Database implements StoreDelegate {
     private String name;
 
     private final AtomicBoolean open = new AtomicBoolean(false);
-    private final AtomicBoolean opening = new AtomicBoolean(false);
     private final AtomicBoolean closing = new AtomicBoolean(false);
     private final RefCounter storeRef = new RefCounter();
 
@@ -1271,144 +1270,139 @@ public class Database implements StoreDelegate {
             return;
 
         Log.v(TAG, "Opening %s", this);
-        opening.set(true);
-        try {
 
-            // Create the database directory:
-            File dir = new File(path);
-            if (!dir.exists()) {
-                if (!dir.mkdirs())
-                    throw new CouchbaseLiteException("Cannot create database directory",
-                            Status.INTERNAL_SERVER_ERROR);
-            } else if (!dir.isDirectory())
-                throw new CouchbaseLiteException("Database directory is not directory",
+        // Create the database directory:
+        File dir = new File(path);
+        if (!dir.exists()) {
+            if (!dir.mkdirs())
+                throw new CouchbaseLiteException("Cannot create database directory",
                         Status.INTERNAL_SERVER_ERROR);
+        } else if (!dir.isDirectory())
+            throw new CouchbaseLiteException("Database directory is not directory",
+                    Status.INTERNAL_SERVER_ERROR);
 
-            String storageType = options.getStorageType();
-            if (storageType == null) {
-                storageType = manager.getStorageType();
-                if (storageType == null)
-                    storageType = DEFAULT_STORAGE;
-            }
-
-            Store primaryStore = createStoreInstance(storageType);
-            if (primaryStore == null) {
-                if (storageType.equals(Manager.SQLITE_STORAGE) || storageType.equals(Manager.FORESTDB_STORAGE))
-                    Log.w(TAG, "storageType is '%s' but no class implementation found", storageType);
-                throw new CouchbaseLiteException("Can't open database in that storage format",
-                        Status.INVALID_STORAGE_TYPE);
-            }
-
-            boolean primarySQLite = Manager.SQLITE_STORAGE.equals(storageType);
-            Store otherStore = createStoreInstance(primarySQLite ? Manager.FORESTDB_STORAGE : Manager.SQLITE_STORAGE);
-
-            boolean upgrade = false;
-            if (options.getStorageType() != null) {
-                // If explicit storage type given in options, always use primary storage type,
-                // and if secondary db exists, try to upgrade from it:
-                if (otherStore != null && otherStore.databaseExists(path) && !primaryStore.databaseExists(path))
-                    upgrade = true;
-
-                if (upgrade && primarySQLite)
-                    throw new CouchbaseLiteException("Cannot upgrade to SQLite Storage", Status.INVALID_STORAGE_TYPE);
-            } else {
-                // If options don't specify, use primary unless secondary db already exists in dir:
-                if (otherStore != null && otherStore.databaseExists(path))
-                    primaryStore = otherStore;
-            }
-
-            store = primaryStore;
-            store.setAutoCompact(autoCompact);
-
-            // Set encryption key:
-            SymmetricKey encryptionKey = null;
-            if (store instanceof EncryptableStore) {
-                Object keyOrPassword = options.getEncryptionKey();
-                if (keyOrPassword != null) {
-                    encryptionKey = createSymmetricKey(keyOrPassword);
-                    ((EncryptableStore) store).setEncryptionKey(encryptionKey);
-                }
-            }
-
-            store.open();
-
-            // First-time setup:
-            if (privateUUID() == null) {
-                if (store.setInfo("privateUUID", Misc.CreateUUID()) != Status.OK)
-                    throw new CouchbaseLiteException("Unable to set privateUUID in info", Status.DB_ERROR);
-                if (store.setInfo("publicUUID", Misc.CreateUUID()) != Status.OK)
-                    throw new CouchbaseLiteException("Unable to set publicUUID in info", Status.DB_ERROR);
-            }
-
-            String sMaxRevs = store.getInfo("max_revs");
-            int maxRevs = (sMaxRevs == null) ? DEFAULT_MAX_REVS : Integer.parseInt(sMaxRevs);
-            store.setMaxRevTreeDepth(maxRevs);
-
-            // NOTE: Migrate attachment directory path if necessary
-            // https://github.com/couchbase/couchbase-lite-java-core/issues/604
-            File obsoletedAttachmentStorePath = new File(getObsoletedAttachmentStorePath());
-            if (obsoletedAttachmentStorePath != null &&
-                    obsoletedAttachmentStorePath.exists() &&
-                    obsoletedAttachmentStorePath.isDirectory()) {
-                File attachmentStorePath = new File(getAttachmentStorePath());
-                if (attachmentStorePath != null && !attachmentStorePath.exists()) {
-                    boolean success = obsoletedAttachmentStorePath.renameTo(attachmentStorePath);
-                    if (!success) {
-                        Log.e(Database.TAG, "Could not rename attachment store path");
-                        store.close();
-                        //store = null;
-                        throw new CouchbaseLiteException("Could not rename attachment store path",
-                                Status.INTERNAL_SERVER_ERROR);
-                    }
-                }
-            }
-
-            // NOTE: obsoleted directory is /files/<database name>/attachments/xxxx
-            //       Needs to delete /files/<database name>/ too
-            File obsoletedAttachmentStoreParentPath = new File(getObsoletedAttachmentStoreParentPath());
-            if (obsoletedAttachmentStoreParentPath != null &&
-                    obsoletedAttachmentStoreParentPath.exists()) {
-                obsoletedAttachmentStoreParentPath.delete();
-            }
-
-            try {
-                if (isBlobstoreMigrated() || !manager.isAutoMigrateBlobStoreFilename()) {
-                    attachments = new BlobStore(manager.getContext(),
-                            getAttachmentStorePath(), encryptionKey, false);
-                } else {
-                    attachments = new BlobStore(manager.getContext(),
-                            getAttachmentStorePath(), encryptionKey, true);
-                    markBlobstoreMigrated();
-                }
-
-            } catch (IllegalArgumentException e) {
-                Log.e(Database.TAG, "Could not initialize attachment store", e);
-                store.close();
-                //store = null;
-                throw new CouchbaseLiteException("Could not initialize attachment store", e,
-                        Status.INTERNAL_SERVER_ERROR);
-            }
-
-            open.set(true);
-
-            if (upgrade) {
-                Log.i(TAG, "Upgrading to %s ...", storageType);
-                String dbPath = new File(path, "db.sqlite3").getAbsolutePath();
-                DatabaseUpgrade upgrader = new DatabaseUpgrade(manager, this, dbPath);
-                if (!upgrader.importData()) {
-                    Log.w(TAG, "Upgrade to %s failed", storageType);
-                    upgrader.backOut();
-                    close();
-                    throw new CouchbaseLiteException("Cannot upgrade to " + storageType, Status.DB_ERROR);
-                } else {
-                    upgrader.deleteSQLiteFiles();
-                }
-            }
-
-            scheduleDocumentExpiration(kHousekeepingDelayAfterOpening);
-        }finally{
-            opening.set(false);
+        String storageType = options.getStorageType();
+        if (storageType == null) {
+            storageType = manager.getStorageType();
+            if (storageType == null)
+                storageType = DEFAULT_STORAGE;
         }
+
+        Store primaryStore = createStoreInstance(storageType);
+        if (primaryStore == null) {
+            if (storageType.equals(Manager.SQLITE_STORAGE) || storageType.equals(Manager.FORESTDB_STORAGE))
+                Log.w(TAG, "storageType is '%s' but no class implementation found", storageType);
+            throw new CouchbaseLiteException("Can't open database in that storage format",
+                    Status.INVALID_STORAGE_TYPE);
+        }
+
+        boolean primarySQLite = Manager.SQLITE_STORAGE.equals(storageType);
+        Store otherStore = createStoreInstance(primarySQLite ? Manager.FORESTDB_STORAGE : Manager.SQLITE_STORAGE);
+
+        boolean upgrade = false;
+        if (options.getStorageType() != null) {
+            // If explicit storage type given in options, always use primary storage type,
+            // and if secondary db exists, try to upgrade from it:
+            if (otherStore != null && otherStore.databaseExists(path) && !primaryStore.databaseExists(path))
+                upgrade = true;
+
+            if (upgrade && primarySQLite)
+                throw new CouchbaseLiteException("Cannot upgrade to SQLite Storage", Status.INVALID_STORAGE_TYPE);
+        } else {
+            // If options don't specify, use primary unless secondary db already exists in dir:
+            if (otherStore != null && otherStore.databaseExists(path))
+                primaryStore = otherStore;
+        }
+
+        store = primaryStore;
+        store.setAutoCompact(autoCompact);
+
+        // Set encryption key:
+        SymmetricKey encryptionKey = null;
+        if (store instanceof EncryptableStore) {
+            Object keyOrPassword = options.getEncryptionKey();
+            if (keyOrPassword != null) {
+                encryptionKey = createSymmetricKey(keyOrPassword);
+                ((EncryptableStore) store).setEncryptionKey(encryptionKey);
+            }
+        }
+
+        store.open();
+
+        open.set(true);
+
+        // First-time setup:
+        if (privateUUID() == null) {
+            if (store.setInfo("privateUUID", Misc.CreateUUID()) != Status.OK)
+                throw new CouchbaseLiteException("Unable to set privateUUID in info", Status.DB_ERROR);
+            if (store.setInfo("publicUUID", Misc.CreateUUID()) != Status.OK)
+                throw new CouchbaseLiteException("Unable to set publicUUID in info", Status.DB_ERROR);
+        }
+
+        String sMaxRevs = store.getInfo("max_revs");
+        int maxRevs = (sMaxRevs == null) ? DEFAULT_MAX_REVS : Integer.parseInt(sMaxRevs);
+        store.setMaxRevTreeDepth(maxRevs);
+
+        // NOTE: Migrate attachment directory path if necessary
+        // https://github.com/couchbase/couchbase-lite-java-core/issues/604
+        File obsoletedAttachmentStorePath = new File(getObsoletedAttachmentStorePath());
+        if (obsoletedAttachmentStorePath != null &&
+                obsoletedAttachmentStorePath.exists() &&
+                obsoletedAttachmentStorePath.isDirectory()) {
+            File attachmentStorePath = new File(getAttachmentStorePath());
+            if (attachmentStorePath != null && !attachmentStorePath.exists()) {
+                boolean success = obsoletedAttachmentStorePath.renameTo(attachmentStorePath);
+                if (!success) {
+                    Log.e(Database.TAG, "Could not rename attachment store path");
+                    store.close();
+                    //store = null;
+                    throw new CouchbaseLiteException("Could not rename attachment store path",
+                            Status.INTERNAL_SERVER_ERROR);
+                }
+            }
+        }
+
+        // NOTE: obsoleted directory is /files/<database name>/attachments/xxxx
+        //       Needs to delete /files/<database name>/ too
+        File obsoletedAttachmentStoreParentPath = new File(getObsoletedAttachmentStoreParentPath());
+        if (obsoletedAttachmentStoreParentPath != null &&
+                obsoletedAttachmentStoreParentPath.exists()) {
+            obsoletedAttachmentStoreParentPath.delete();
+        }
+
+        try {
+            if (isBlobstoreMigrated() || !manager.isAutoMigrateBlobStoreFilename()) {
+                attachments = new BlobStore(manager.getContext(),
+                        getAttachmentStorePath(), encryptionKey, false);
+            } else {
+                attachments = new BlobStore(manager.getContext(),
+                        getAttachmentStorePath(), encryptionKey, true);
+                markBlobstoreMigrated();
+            }
+
+        } catch (IllegalArgumentException e) {
+            Log.e(Database.TAG, "Could not initialize attachment store", e);
+            store.close();
+            //store = null;
+            throw new CouchbaseLiteException("Could not initialize attachment store", e,
+                    Status.INTERNAL_SERVER_ERROR);
+        }
+
+        if (upgrade) {
+            Log.i(TAG, "Upgrading to %s ...", storageType);
+            String dbPath = new File(path, "db.sqlite3").getAbsolutePath();
+            DatabaseUpgrade upgrader = new DatabaseUpgrade(manager, this, dbPath);
+            if (!upgrader.importData()) {
+                Log.w(TAG, "Upgrade to %s failed", storageType);
+                upgrader.backOut();
+                close();
+                throw new CouchbaseLiteException("Cannot upgrade to " + storageType, Status.DB_ERROR);
+            } else {
+                upgrader.deleteSQLiteFiles();
+            }
+        }
+
+        scheduleDocumentExpiration(kHousekeepingDelayAfterOpening);
     }
 
     /**
@@ -2143,7 +2137,7 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Private
     public boolean isOpen() {
-        return (open.get() && !closing.get()) || opening.get();
+        return (open.get() && !closing.get());
     }
 
     @InterfaceAudience.Private

--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -15,6 +15,7 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.internal.RevisionInternal;
+import com.couchbase.lite.store.Store;
 import com.couchbase.lite.util.Log;
 
 import java.net.URL;
@@ -150,10 +151,15 @@ public class Document {
      * A date/time after which this document will be automatically purged.
      */
     public Date getExpirationDate() {
-        long timestamp = database.getStore().expirationOfDocument(documentId);
-        if (timestamp == 0)
-            return null;
-        return new Date(timestamp);
+        Store store = database.retainStore();
+        try {
+            long timestamp = store.expirationOfDocument(documentId);
+            if (timestamp == 0)
+                return null;
+            return new Date(timestamp);
+        } finally {
+            database.releaseStore();
+        }
     }
 
     public void setExpirationDate(Date date) {
@@ -464,19 +470,24 @@ public class Document {
     @InterfaceAudience.Private
     protected List<SavedRevision> getLeafRevisions(boolean includeDeleted)
             throws CouchbaseLiteException {
-        List<SavedRevision> result = new ArrayList<SavedRevision>();
-        RevisionList revs = database.getStore().getAllRevisions(documentId, true);
-        if (revs != null) {
-            for (RevisionInternal rev : revs) {
-                // add it to result, unless we are not supposed to include deleted and it's deleted
-                if (!includeDeleted && rev.isDeleted()) {
-                    // don't add it
-                } else {
-                    result.add(getRevisionFromRev(rev));
+        Store store = database.retainStore();
+        try {
+            List<SavedRevision> result = new ArrayList<SavedRevision>();
+            RevisionList revs = store.getAllRevisions(documentId, true);
+            if (revs != null) {
+                for (RevisionInternal rev : revs) {
+                    // add it to result, unless we are not supposed to include deleted and it's deleted
+                    if (!includeDeleted && rev.isDeleted()) {
+                        // don't add it
+                    } else {
+                        result.add(getRevisionFromRev(rev));
+                    }
                 }
             }
+            return Collections.unmodifiableList(result);
+        } finally {
+            database.releaseStore();
         }
-        return Collections.unmodifiableList(result);
     }
 
     protected Map<String, Object> propertiesToInsert(Map<String, Object> properties)

--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -18,7 +18,6 @@
 package com.couchbase.lite;
 
 import com.couchbase.lite.internal.InterfaceAudience;
-import com.couchbase.lite.store.Store;
 import com.couchbase.lite.store.ViewStore;
 import com.couchbase.lite.store.ViewStoreDelegate;
 import com.couchbase.lite.util.Log;
@@ -54,15 +53,10 @@ public final class View implements ViewStoreDelegate {
     protected View(Database database, String name, boolean create) throws CouchbaseLiteException {
         this.database = database;
         this.name = name;
-        Store store = database.retainStore();
-        try {
-            this.viewStore = store.getViewStorage(name, create);
-            if (this.viewStore == null)
-                throw new CouchbaseLiteException(Status.NOT_FOUND);
-            this.viewStore.setDelegate(this);
-        } finally {
-            database.releaseStore();
-        }
+        this.viewStore = database.getViewStorage(name, create);
+        if (this.viewStore == null)
+            throw new CouchbaseLiteException(Status.NOT_FOUND);
+        this.viewStore.setDelegate(this);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/couchbase/lite/View.java
+++ b/src/main/java/com/couchbase/lite/View.java
@@ -18,6 +18,7 @@
 package com.couchbase.lite;
 
 import com.couchbase.lite.internal.InterfaceAudience;
+import com.couchbase.lite.store.Store;
 import com.couchbase.lite.store.ViewStore;
 import com.couchbase.lite.store.ViewStoreDelegate;
 import com.couchbase.lite.util.Log;
@@ -53,10 +54,15 @@ public final class View implements ViewStoreDelegate {
     protected View(Database database, String name, boolean create) throws CouchbaseLiteException {
         this.database = database;
         this.name = name;
-        this.viewStore = database.getStore().getViewStorage(name, create);
-        if (this.viewStore == null)
-            throw new CouchbaseLiteException(Status.NOT_FOUND);
-        this.viewStore.setDelegate(this);
+        Store store = database.retainStore();
+        try {
+            this.viewStore = store.getViewStorage(name, create);
+            if (this.viewStore == null)
+                throw new CouchbaseLiteException(Status.NOT_FOUND);
+            this.viewStore.setDelegate(this);
+        } finally {
+            database.releaseStore();
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -24,7 +24,6 @@ import com.couchbase.lite.TransactionalTask;
 import com.couchbase.lite.internal.InterfaceAudience;
 import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.storage.SQLException;
-import com.couchbase.lite.store.Store;
 import com.couchbase.lite.support.BatchProcessor;
 import com.couchbase.lite.support.Batcher;
 import com.couchbase.lite.support.CustomFuture;
@@ -558,77 +557,67 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         Log.d(TAG, this + " inserting " + downloads.size() + " revisions...");
         final long time = System.currentTimeMillis();
         Collections.sort(downloads, getRevisionListComparator());
-        Store store = db.retainStore();
-        try {
-            store.runInTransaction(new TransactionalTask() {
-                @Override
-                public boolean run() {
-                    boolean success = false;
-                    try {
-                        for (RevisionInternal rev : downloads) {
-                            long fakeSequence = rev.getSequence();
-                            List<String> history = db.parseCouchDBRevisionHistory(rev.getProperties());
-                            if (history.isEmpty() && rev.getGeneration() > 1) {
-                                Log.w(TAG, "%s: Missing revision history in response for: %s", this, rev);
-                                setError(new CouchbaseLiteException(Status.UPSTREAM_ERROR));
+        db.runInTransaction(new TransactionalTask() {
+            @Override
+            public boolean run() {
+                boolean success = false;
+                try {
+                    for (RevisionInternal rev : downloads) {
+                        long fakeSequence = rev.getSequence();
+                        List<String> history = db.parseCouchDBRevisionHistory(rev.getProperties());
+                        if (history.isEmpty() && rev.getGeneration() > 1) {
+                            Log.w(TAG, "%s: Missing revision history in response for: %s", this, rev);
+                            setError(new CouchbaseLiteException(Status.UPSTREAM_ERROR));
+                            continue;
+                        }
+
+                        Log.v(TAG, "%s: inserting %s %s", this, rev.getDocID(), history);
+
+                        // Insert the revision
+                        try {
+                            db.forceInsert(rev, history, remote);
+                        } catch (CouchbaseLiteException e) {
+                            if (e.getCBLStatus().getCode() == Status.FORBIDDEN) {
+                                Log.i(TAG, "%s: Remote rev failed validation: %s", this, rev);
+                            } else {
+                                Log.w(TAG, "%s: failed to write %s: status=%s",
+                                        this, rev, e.getCBLStatus().getCode());
+                                setError(new RemoteRequestResponseException(e.getCBLStatus().getCode(), null));
                                 continue;
                             }
-
-                            Log.v(TAG, "%s: inserting %s %s", this, rev.getDocID(), history);
-
-                            // Insert the revision
-                            try {
-                                db.forceInsert(rev, history, remote);
-                            } catch (CouchbaseLiteException e) {
-                                if (e.getCBLStatus().getCode() == Status.FORBIDDEN) {
-                                    Log.i(TAG, "%s: Remote rev failed validation: %s", this, rev);
-                                } else {
-                                    Log.w(TAG, "%s: failed to write %s: status=%s",
-                                            this, rev, e.getCBLStatus().getCode());
-                                    setError(new RemoteRequestResponseException(e.getCBLStatus().getCode(), null));
-                                    continue;
-                                }
-                            }
-
-                            //if(rev.getBody() != null) rev.getBody().release();
-                            if (rev.getBody() != null) rev.getBody().compact();
-
-                            // Mark this revision's fake sequence as processed:
-                            pendingSequences.removeSequence(fakeSequence);
                         }
+                        if (rev.getBody() != null) rev.getBody().compact();
 
-                        Log.v(TAG, "%s: finished inserting %d revisions", this, downloads.size());
-                        success = true;
-
-                    } catch (SQLException e) {
-                        Log.e(TAG, this + ": Exception inserting revisions", e);
-                    } finally {
-                        if (success) {
-
-                            // Checkpoint:
-                            setLastSequence(pendingSequences.getCheckpointedValue());
-
-                            long delta = System.currentTimeMillis() - time;
-                            Log.v(TAG,
-                                    "%s: inserted %d revs in %d milliseconds",
-                                    this, downloads.size(), delta);
-
-                            int newCompletedChangesCount = getCompletedChangesCount().get() + downloads.size();
-                            Log.d(TAG,
-                                    "%s insertDownloads() updating completedChangesCount from %d -> %d ",
-                                    this, getCompletedChangesCount().get(), newCompletedChangesCount);
-
-                            addToCompletedChangesCount(downloads.size());
-                        }
-
-                        pauseOrResume();
-                        return success;
+                        // Mark this revision's fake sequence as processed:
+                        pendingSequences.removeSequence(fakeSequence);
                     }
+
+                    Log.v(TAG, "%s: finished inserting %d revisions", this, downloads.size());
+                    success = true;
+                } catch (SQLException e) {
+                    Log.e(TAG, this + ": Exception inserting revisions", e);
+                } finally {
+                    if (success) {
+                        // Checkpoint:
+                        setLastSequence(pendingSequences.getCheckpointedValue());
+
+                        long delta = System.currentTimeMillis() - time;
+                        Log.v(TAG,
+                                "%s: inserted %d revs in %d milliseconds",
+                                this, downloads.size(), delta);
+
+                        int newCompletedChangesCount = getCompletedChangesCount().get() + downloads.size();
+                        Log.d(TAG,
+                                "%s insertDownloads() updating completedChangesCount from %d -> %d ",
+                                this, getCompletedChangesCount().get(), newCompletedChangesCount);
+
+                        addToCompletedChangesCount(downloads.size());
+                    }
+                    pauseOrResume();
+                    return success;
                 }
-            });
-        } finally {
-            db.releaseStore();
-        }
+            }
+        });
     }
 
     @InterfaceAudience.Private

--- a/src/main/java/com/couchbase/lite/util/RefCounter.java
+++ b/src/main/java/com/couchbase/lite/util/RefCounter.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016 Couchbase, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.couchbase.lite.util;
+
+/**
+ * Created by hideki on 9/30/16.
+ */
+public class RefCounter {
+    private int refCount = 0;
+
+    public synchronized void retain() {
+        refCount++;
+    }
+
+    public synchronized void release() {
+        if (refCount == 0)
+            throw new IllegalStateException("Reference counter is set to zero -- cannot release!");
+        if (--refCount == 0) {
+            notifyAll();
+        }
+    }
+
+    public synchronized int count() {
+        return refCount;
+    }
+
+    public synchronized void await() {
+        while (count() != 0) {
+            try {
+                wait();
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ticket: couchbase/couchbase-lite-android#1009

Issue: Database class implementation allows to close database while other thread is doing read/write database operation.

Solution: By implementing reference count for store instance, `Database.close()` method waits till reference count becomes `0`. In addition,  `Database` class's methods throws RuntimeException if database is already closed.

- `CouchbaseLiteRuntimeException`: If methods throws `CouchbaseLiteException`, it requires API change, and user needs to rewrite (adding try-catch block). If `CouchbaseLiteException ` extends from `RuntimeExcepiton`, user will not be forced to catch `CouchbaseLiteException`. So I decided to add new Exception which is extended from `RuntimeException`.
- `RefCounter`: just managing number of reference. This is thread-safe.
- `Database` class: All methods which access to internal database check if database is open, and retain reference count, at end of methods release reference.
- DatbaseUpgrade, Document, View, PullerInternal, and Router classes: Just modified accordingly.