### PR TITLE
Fixed #878 - Fixed canonicalJSON output.

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RevisionUtils.java
+++ b/src/main/java/com/couchbase/lite/support/RevisionUtils.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * Created by hideki on 6/17/15.
@@ -132,11 +134,10 @@ public class RevisionUtils {
      */
     @InterfaceAudience.Private
     public static byte[] asCanonicalJSON(Map<String, Object> props) {
-        if (props == null) {
+        if (props == null)
             return null;
-        }
 
-        Map<String, Object> properties = new HashMap<String, Object>(props.size());
+        Map<String, Object> properties = new TreeMap<String, Object>();
         for (String key : props.keySet()) {
             boolean shouldAdd = false;
             if (!key.startsWith("_")) {
@@ -150,7 +151,11 @@ public class RevisionUtils {
                 return null;
             }
             if (shouldAdd) {
-                properties.put(key, props.get(key));
+                Object value = props.get(key);
+                if (value instanceof Map)
+                    properties.put(key, convert((Map) value));
+                else
+                    properties.put(key, value);
             }
         }
 
@@ -161,6 +166,20 @@ public class RevisionUtils {
             Log.e(Database.TAG, "Error serializing " + properties + " to JSON", e);
         }
         return json;
+    }
+
+    protected static SortedMap<String, Object> convert(Map<String, Object> map) {
+        SortedMap<String, Object> dest = new TreeMap<String, Object>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                dest.put(key, convert((Map<String, Object>) value));
+            } else {
+                dest.put(key, value);
+            }
+        }
+        return dest;
     }
 
     /**


### PR DESCRIPTION
- to make the natural ordering of json keys, applied SortedMap/TreeMap recursively before calling `ObjectMapper.writeValueAsBytes(...)`