### PR TITLE
Fixed Android Issue 876 - Feature request: log current version

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -110,8 +110,7 @@ public final class Manager {
      */
     @InterfaceAudience.Public
     public Manager(Context context, ManagerOptions options) throws IOException {
-
-        Log.d(Database.TAG, "Starting Manager version: %s", Manager.VERSION);
+        Log.i(Database.TAG, "### %s ###", getFullVersionInfo());
 
         this.context = context;
         this.directoryFile = context.getFilesDir();
@@ -1050,5 +1049,11 @@ public final class Manager {
                     Version.getCommitHash());
         }
         return USER_AGENT;
+    }
+
+    public static String getFullVersionInfo() {
+        return String.format(Locale.ENGLISH, "Couchbase Lite %s (%s)",
+                Version.getVersionName(),
+                Version.getCommitHash());
     }
 }


### PR DESCRIPTION
Fixed https://github.com/couchbase/couchbase-lite-android/issues/876

- Print Couchbase Lite version number when Manager is instantiated.  (iOS: https://github.com/couchbase/couchbase-lite-ios/blob/66133e2ec76851ed16828f3b05476de0671ced3e/Source/API/CBLManager.m#L120)