### PR TITLE
Fixed #1126 - ChangeTracker should stop for permanent error (ex 404)

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -257,7 +257,7 @@ public class ChangeTracker implements Runnable {
         // If the error may be transient (flaky network, server glitch), retry:
         // condition: non-permanent error && (continuous or transient)
         if (!Utils.isPermanentError(resp) &&
-                (mode == ChangeTrackerMode.LongPoll || Utils.isTransientErrorWithSpecialCases(resp))) {
+                (mode == ChangeTrackerMode.LongPoll || Utils.isTransientError(resp))) {
             return false;
         } else {
             Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker got error %d", this, resp.code());

--- a/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
+++ b/src/main/java/com/couchbase/lite/replicator/ChangeTracker.java
@@ -250,17 +250,20 @@ public class ChangeTracker implements Runnable {
         }
     }
 
-    private boolean isResponseFailed(Response response) {
-        //StatusLine status = response.getStatusLine();
-        if (response.code() >= 300 &&
-                ((mode == ChangeTrackerMode.LongPoll && !Utils.isTransientError(response.code())) ||
-                        mode != ChangeTrackerMode.LongPoll)) {
-            Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker got error %d",
-                    this, response.code());
-            error = new RemoteRequestResponseException(response.code(), response.message());
+    private boolean isResponseFailed(Response resp) {
+        if (resp.code() < 300)
+            return false;
+
+        // If the error may be transient (flaky network, server glitch), retry:
+        // condition: non-permanent error && (continuous or transient)
+        if (!Utils.isPermanentError(resp) &&
+                (mode == ChangeTrackerMode.LongPoll || Utils.isTransientErrorWithSpecialCases(resp))) {
+            return false;
+        } else {
+            Log.w(Log.TAG_CHANGE_TRACKER, "%s: Change tracker got error %d", this, resp.code());
+            error = new RemoteRequestResponseException(resp.code(), resp.message());
             return true;
         }
-        return false;
     }
 
     private boolean retryIfFailedPost(Response response) {
@@ -277,6 +280,7 @@ public class ChangeTracker implements Runnable {
     private boolean isCloudantAuthError(Response response) {
         String server = response.header("Server");
         // Cloudant could send `CouchDB/ad97a06 (Erlang OTP/17)` as Server header value
+        // Another cloudant server value example: `CouchDB/1.0.2`
         if (server == null || server.indexOf("CouchDB/") == -1)// (Accurate as of 5/2016)
             return false;
         // Note: 401 (UNAUTHORIZED) might not be caused by Cloudant

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -84,14 +84,6 @@ public class Utils {
         return (code >= 400 && code <= 405) || (code == 407) || (code >= 409 && code <= 499);
     }
 
-    public static boolean isTransientErrorWithSpecialCases(Response response) {
-        return isTransientErrorWithSpecialCases(response.code());
-    }
-
-    public static boolean isTransientErrorWithSpecialCases(int code) {
-        return code == 406 || code == 408 || isTransientError(code);
-    }
-
     /**
      * in CBLMisc.m
      * BOOL CBLMayBeTransientError( NSError* error )
@@ -124,11 +116,8 @@ public class Utils {
     }
 
     public static boolean isTransientError(int code) {
-        if (code == 500 || code == 502 || code == 503 || code == 504 ||
-                code == Status.REQUEST_TIMEOUT) {
-            return true;
-        }
-        return false;
+        // Note: Status.NOT_ACCEPTABLE = 406, Status.REQUEST_TIMEOUT = 408
+        return code == 406 || code == 408 || code == 500 || code == 502 || code == 503 || code == 504;
     }
 
     public static boolean isDocumentError(Throwable throwable) {

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -77,11 +77,8 @@ public class Utils {
                 || code == RemoteRequestResponseException.USER_DENIED_AUTH)
             return true;
 
-        // 406 - in Test cases, server return 406 because of CouchDB API
-        //       http://docs.couchdb.org/en/latest/api/database/bulk-api.html
-        //       GET /{db}/_all_docs or POST /{db}/_all_docs
-        // 408 - Listener might encounter SocketTimeout under weak network connectivity
-        return (code >= 400 && code <= 405) || (code == 407) || (code >= 409 && code <= 499);
+        // 408 - Java Listener might encounter SocketTimeout under weak network connectivity.
+        return (code >= 400 && code <= 407) || (code >= 409 && code <= 499);
     }
 
     /**
@@ -116,8 +113,8 @@ public class Utils {
     }
 
     public static boolean isTransientError(int code) {
-        // Note: Status.NOT_ACCEPTABLE = 406, Status.REQUEST_TIMEOUT = 408
-        return code == 406 || code == 408 || code == 500 || code == 502 || code == 503 || code == 504;
+        // Note: Status.REQUEST_TIMEOUT = 408
+        return code == 408 || code == 500 || code == 502 || code == 503 || code == 504;
     }
 
     public static boolean isDocumentError(Throwable throwable) {

--- a/src/main/java/com/couchbase/lite/util/Utils.java
+++ b/src/main/java/com/couchbase/lite/util/Utils.java
@@ -68,8 +68,11 @@ public class Utils {
         }
     }
 
-    public static boolean isPermanentError(int code) {
+    public static boolean isPermanentError(Response response) {
+        return isPermanentError(response.code());
+    }
 
+    public static boolean isPermanentError(int code) {
         if (code == RemoteRequestResponseException.BAD_URL
                 || code == RemoteRequestResponseException.USER_DENIED_AUTH)
             return true;
@@ -79,6 +82,14 @@ public class Utils {
         //       GET /{db}/_all_docs or POST /{db}/_all_docs
         // 408 - Listener might encounter SocketTimeout under weak network connectivity
         return (code >= 400 && code <= 405) || (code == 407) || (code >= 409 && code <= 499);
+    }
+
+    public static boolean isTransientErrorWithSpecialCases(Response response) {
+        return isTransientErrorWithSpecialCases(response.code());
+    }
+
+    public static boolean isTransientErrorWithSpecialCases(int code) {
+        return code == 406 || code == 408 || isTransientError(code);
     }
 
     /**
@@ -112,9 +123,9 @@ public class Utils {
         return isTransientError(response.code());
     }
 
-    public static boolean isTransientError(int statusCode) {
-        if (statusCode == 500 || statusCode == 502 || statusCode == 503 || statusCode == 504 ||
-                statusCode == Status.REQUEST_TIMEOUT) {
+    public static boolean isTransientError(int code) {
+        if (code == 500 || code == 502 || code == 503 || code == 504 ||
+                code == Status.REQUEST_TIMEOUT) {
             return true;
         }
         return false;


### PR DESCRIPTION
- Previously ChangeTracker does not check if error is permanent error which check includes 404 or 40x check.