### PR TITLE
Round progress to floor instead of rounding up to prevent misleading progress = 100

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -1023,7 +1023,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                 status = "Offline";  // nonstandard
             }
         }
-        int progress = (total > 0) ? Math.round(100 * processed / (float) total) : 0;
+        int progress = (total > 0) ? (int) 100 * processed / total : 0;
 
         activity.put("type", "Replication");
         activity.put("task", replicator.getSessionID());


### PR DESCRIPTION
When the app is syncing > 30K documents on Android, the `changes` is so close to the `Processed`:

``` 
status": "Processed A / B changes",
progress: 100
 ```
A is so close to B that progress is always 100 which is misleading. 

**Example from actual sync:**
Total documents that needed to be synced: 385,000
```
"status": "Processed 68108 / 68308 changes",
"progress": 100,
```
Both Processed and changes stay very close together.

Can progress be rounded down?