### PR TITLE
Fixed #1385 - CBLReplicatorExecutor still exists after stopping the r…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -1478,6 +1478,11 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 clearDbRef();
 
                 notifyChangeListenersStateTransition(transition);
+
+                // ask executor to shutdown. this does not force to shutdown.
+                // https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html#shutdown()
+                if (executor != null && !executor.isShutdown())
+                    executor.shutdown();
             }
         });
     }


### PR DESCRIPTION
…eplicator

- CBLReplicatorExecutor was shutdown in finalized method. Ask executor to shutdown at end of STOPPED state change handler. `ExecutorService.shutdown()` does not force to shutdown as some tasks could be in the queue, but this will no longer accept new task request.