### PR TITLE
Fixed #1501 - enhance DeepClone and canonicalJSON

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RevisionUtils.java
+++ b/src/main/java/com/couchbase/lite/support/RevisionUtils.java
@@ -163,8 +163,10 @@ public class RevisionUtils {
             // serialization or not: if enabled, additional sorting step is performed if necessary
             // (not necessary for SortedMaps), if disabled, no additional sorting is needed.
             // Feature is disabled by default.
+            //
+            // Currently ORDER_MAP_ENTRIES_BY_KEYS is not applied here. This is covered by DeepClone.java
+            // `.writer(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)`
             json = Manager.getObjectMapper()
-                    .writer(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
                     .writeValueAsBytes(properties);
         } catch (Exception e) {
             Log.e(Database.TAG, "Error serializing " + properties + " to JSON", e);

--- a/src/main/java/com/couchbase/lite/util/DeepClone.java
+++ b/src/main/java/com/couchbase/lite/util/DeepClone.java
@@ -65,7 +65,9 @@ public final class DeepClone {
 
     private static <E> Collection<E> deepCloneCollection(final Collection<E> input) {
         Collection<E> clone;
-        if (input instanceof LinkedList<?>)
+        if (input instanceof ArrayList<?>)
+            clone = new ArrayList<E>();
+        else if (input instanceof LinkedList<?>)
             clone = new LinkedList<E>();
         else if (input instanceof SortedSet<?>)
             clone = new TreeSet<E>();
@@ -80,16 +82,10 @@ public final class DeepClone {
     }
 
     private static <K, V> Map<K, V> deepCloneMap(final Map<K, V> map) {
-        Map<K, V> clone;
-        if (map instanceof LinkedHashMap<?, ?>)
-            clone = new LinkedHashMap<K, V>();
-        else if (map instanceof TreeMap<?, ?>)
-            clone = new TreeMap<K, V>();
-        else
-            clone = new HashMap<K, V>();
-
+        // Force to use TreeMap to generate canonical JSON.
+        Map<K, V> clone = new TreeMap<K, V>();
         for (Map.Entry<K, V> entry : map.entrySet())
-            clone.put(deepClone(entry.getKey()), deepClone(entry.getValue()));
+            clone.put(entry.getKey(), deepClone(entry.getValue()));
         return clone;
     }
 }


### PR DESCRIPTION
- Disabled `ORDER_MAP_ENTRIES_BY_KEYS` of Jackson
- Force to use `TreeMap` for any Map in DeepClone