### PR TITLE
Fixed #1500 - OutOfMemoryError on Jenkins

### DIFF
--- a/src/main/java/com/couchbase/lite/util/DeepClone.java
+++ b/src/main/java/com/couchbase/lite/util/DeepClone.java
@@ -43,8 +43,6 @@ public final class DeepClone {
             return (T) deepCloneCollection((Collection<?>) input);
         } else if (input instanceof Object[]) {
             return (T) deepCloneObjectArray((Object[]) input);
-        } else if (input.getClass().isArray()) {
-            return (T) clonePrimitiveArray(input);
         }
         return input;
     }


### PR DESCRIPTION
- Variety of tests fail after implemented DeepClone. Some of failing test contains large char array. Copying the primitive array consumes a lot of memory. Disabled copying the primitive array in DeepClone