### PR TITLE
Fixed #1507 - Inappropriate Exception message is thrown from SQLite

### DIFF
--- a/src/main/java/com/couchbase/lite/storage/SQLException.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLException.java
@@ -22,6 +22,7 @@ public class SQLException extends RuntimeException {
     // Note: needs to define other error code
     public static final int SQLITE_OK = 0;
     public static final int SQLITE_ERROR = 1;
+    public static final int SQLITE_CORRUPT = 11;
     public static final int SQLITE_CONSTRAINT = 19;
 
     // Extension codes for encryption errors:

--- a/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
@@ -54,7 +54,7 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
 
     @Override
     public boolean open(String path, SymmetricKey encryptionKey) throws SQLException {
-        if(database != null && database.isOpen())
+        if (database != null && database.isOpen())
             return true;
 
         boolean hasError = false;
@@ -72,12 +72,20 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
                     getWALConnectionPoolSize(),
                     null, new ConnectionListener());
             Log.v(Log.TAG_DATABASE, "%s: Opened Android sqlite db", this);
-        } catch(SQLiteDatabaseCorruptException e) {
+        } catch (SQLiteDatabaseCorruptException e) {
             hasError = true;
-            Log.e(Log.TAG_DATABASE, "Unauthorized to open the SQLite database", e);
-            throw new SQLException(SQLException.SQLITE_ENCRYPTION_UNAUTHORIZED,
-                    "Cannot decrypt or access the database");
-        } catch(com.couchbase.lite.internal.database.SQLException e) {
+            // SQLCipher with encryption
+            if (encryptionKey != null && supportEncryption()) {
+                Log.e(Log.TAG_DATABASE, "Unauthorized to open the SQLite database", e);
+                throw new SQLException(SQLException.SQLITE_ENCRYPTION_UNAUTHORIZED,
+                        "Cannot decrypt or access the database");
+            }
+            // Standard SQLite or SQLCipher without encryption
+            else {
+                Log.e(Log.TAG_DATABASE, "The SQLite database file has been corrupted", e);
+                throw new SQLException(SQLException.SQLITE_CORRUPT, e);
+            }
+        } catch (com.couchbase.lite.internal.database.SQLException e) {
             hasError = true;
             Log.e(Log.TAG_DATABASE, "Unable to open the SQLite database", e);
             throw new SQLException(e);

--- a/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
+++ b/src/main/java/com/couchbase/lite/storage/SQLiteStorageEngineBase.java
@@ -82,7 +82,10 @@ public abstract class SQLiteStorageEngineBase implements SQLiteStorageEngine {
             }
             // Standard SQLite or SQLCipher without encryption
             else {
-                Log.e(Log.TAG_DATABASE, "The SQLite database file has been corrupted", e);
+                Log.e(Log.TAG_DATABASE,
+                        "Application might try to open the encrypted database "
+                                + "with the standard SQLite library or no password provided. "
+                                + "Otherwise, the SQLite database file has been corrupted. ", e);
                 throw new SQLException(SQLException.SQLITE_CORRUPT, e);
             }
         } catch (com.couchbase.lite.internal.database.SQLException e) {


### PR DESCRIPTION
Inappropriate Exception message is thrown from SQLite when database corruption happens.
https://github.com/couchbase/couchbase-lite-java-core/issues/1507