### PR TITLE
Fixed - NPE when start replication

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -362,6 +362,7 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Public
     public Replication createPullReplication(URL remote) {
+        if (remote == null) throw new IllegalArgumentException("remote is null");
         if (!isOpen()) throw new CouchbaseLiteRuntimeException("Database is closed.");
         storeRef.retain();
         try {
@@ -379,6 +380,7 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Public
     public Replication createPushReplication(URL remote) {
+        if (remote == null) throw new IllegalArgumentException("remote is null");
         if (!isOpen()) throw new CouchbaseLiteRuntimeException("Database is closed.");
         storeRef.retain();
         try {

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -151,7 +151,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                         HttpClientFactory clientFactory,
                         Replication.Lifecycle lifecycle,
                         Replication parentReplication) {
-
+        if (remote == null) throw new IllegalArgumentException("remote is null");
         Utils.assertNotNull(lifecycle, "Must pass in a non-null lifecycle");
 
         this.parentReplication = parentReplication;


### PR DESCRIPTION
https://github.com/couchbase/couchbase-lite-android/issues/1007

NPE is thrown because remote (URL) variable is `null`. As code never set `null`, I believe user's code set null for `createPullReplicator()/createPushReplication()`'s parameter. To prevent NPE, add null check for remote variable.