### PR TITLE
Fixed #1510 - Mixing HashMap and TreeMap for properties in Document. …

### DIFF
--- a/src/main/java/com/couchbase/lite/support/RevisionUtils.java
+++ b/src/main/java/com/couchbase/lite/support/RevisionUtils.java
@@ -164,10 +164,8 @@ public class RevisionUtils {
             // serialization or not: if enabled, additional sorting step is performed if necessary
             // (not necessary for SortedMaps), if disabled, no additional sorting is needed.
             // Feature is disabled by default.
-            //
-            // Currently ORDER_MAP_ENTRIES_BY_KEYS is not applied here. This is covered by DeepClone.java
-            // `.writer(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)`
             json = Manager.getObjectMapper()
+                    .writer(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
                     .writeValueAsBytes(properties);
         } catch (Exception e) {
             Log.e(Database.TAG, "Error serializing " + properties + " to JSON", e);


### PR DESCRIPTION
Mixing HashMap and TreeMap for properties in Document HashMap allows to generate non-canonical JSON.

https://github.com/couchbase/couchbase-lite-java-core/issues/1510

- There is some ways to create properties variable for RevisionInternal. With current implementation, properties variable type is not guaranteed to be TreeMap. So we need to enable `SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS` to generate canonical JSON. As described in ticket https://github.com/couchbase/couchbase-lite-java-core/issues/1510#issuecomment-257744966, Jackson does not create new TreeMap if Map object is implemented SortedMap interface. So enabling this should not be expensive if properties variable is already TreeMap.