### PR TITLE
Fixed #1495 - Changes feed skipping changes on rapid long poll

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -113,6 +113,9 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     private URL source = null;
 
     // _changes request:
+    private long changesSince = 0;
+    private boolean filled = false;
+    private ChangesOptions changesOptions = null;
     private ReplicationFilter changesFilter;
     Map<String, Object> changesFilterParams = null;
     private boolean longpoll = false;
@@ -204,6 +207,19 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             }
         }
 
+        return result;
+    }
+
+    private long getLongQuery(String param, long defaultValue) {
+        long result = defaultValue;
+        String value = getQuery(param);
+        if (value != null) {
+            try {
+                result = Long.parseLong(value);
+            } catch (NumberFormatException e) {
+                //ignore, will return default value
+            }
+        }
         return result;
     }
 
@@ -1537,19 +1553,22 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         List<Map<String, Object>> entries = new ArrayList<Map<String, Object>>();
         String lastDocID = null;
         Map<String, Object> lastEntry = null;
-        for (RevisionInternal rev : changes) {
-            String docID = rev.getDocID();
-            if (docID.equals(lastDocID)) {
-                Map<String, Object> changesDict = new HashMap<String, Object>();
-                changesDict.put("rev", rev.getRevID());
-                List<Map<String, Object>> inchanges = (List<Map<String, Object>>) lastEntry.get("changes");
-                inchanges.add(changesDict);
-            } else {
-                lastEntry = changesDictForRevision(rev);
-                entries.add(lastEntry);
-                lastDocID = docID;
+        if (changes != null && changes.size() > 0) {
+            for (RevisionInternal rev : changes) {
+                String docID = rev.getDocID();
+                if (docID.equals(lastDocID)) {
+                    Map<String, Object> changesDict = new HashMap<String, Object>();
+                    changesDict.put("rev", rev.getRevID());
+                    List<Map<String, Object>> inchanges = (List<Map<String, Object>>) lastEntry.get("changes");
+                    inchanges.add(changesDict);
+                } else {
+                    lastEntry = changesDictForRevision(rev);
+                    entries.add(lastEntry);
+                    lastDocID = docID;
+                }
             }
         }
+
         // After collecting revisions, sort by sequence:
         Collections.sort(entries, new Comparator<Map<String, Object>>() {
             public int compare(Map<String, Object> e1, Map<String, Object> e2) {
@@ -1622,18 +1641,19 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         }
     }
 
-    private void sendLongpollChanges(List<RevisionInternal> revs) {
-        sendLongpollChanges(revs, 0);
-    }
-
-    private void sendLongpollChanges(List<RevisionInternal> revs, long since) {
+    private void sendLongpollChanges(List<RevisionInternal> revs, long since, ChangesOptions changesOptions) {
         // Ensure that the content type is application/json:
         connection.getResHeader().add("Content-Type", CONTENT_TYPE_JSON);
         sendResponse();
 
         OutputStream os = connection.getResponseOutputStream();
         try {
-            Map<String, Object> body = responseBodyForChanges(revs, since);
+            Map<String, Object> body;
+            if (changesOptions != null && changesOptions.isIncludeConflicts())
+                body = responseBodyForChangesWithConflicts(revs, since);
+            else
+                body = responseBodyForChanges(revs, since);
+
             if (callbackBlock != null) {
                 byte[] data = null;
                 try {
@@ -1678,6 +1698,16 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             // Stop timeout timer:
             stopTimeout();
 
+            // https://github.com/couchbase/couchbase-lite-java-core/issues/1495
+            if (!filled) {
+                filled = true;
+                RevisionList changes = db.changesSince(changesSince, changesOptions, changesFilter, changesFilterParams);
+                if(changes.size() > 0) {
+                    sendLongpollChanges(changes, changesSince, changesOptions);
+                    return;
+                }
+            }
+
             List<RevisionInternal> revs = new ArrayList<RevisionInternal>();
             List<DocumentChange> changes = event.getChanges();
             for (DocumentChange change : changes) {
@@ -1712,10 +1742,15 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                 timeoutLastSeqence = rev.getSequence();
             }
 
+            // feed=longpoll
             if (longpoll) {
                 if (revs.size() > 0)
-                    sendLongpollChanges(revs);
-            } else {
+                    sendLongpollChanges(revs, changesSince, changesOptions);
+                else
+                    startTimeout();
+            }
+            // feed=continuous
+            else {
                 // Restart timeout timer for continuous feed request:
                 startTimeout();
             }
@@ -1749,6 +1784,8 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
     }
 
     private Status doChanges(Database db) {
+        filled = false;
+
         // http://docs.couchdb.org/en/latest/api/database/changes.html
         // http://wiki.apache.org/couchdb/HTTP_database_API#Changes
         changesIncludesDocs = getBooleanQuery("include_docs");
@@ -1763,7 +1800,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         // TODO: descending option is not supported by ChangesOptions
         options.setLimit(getIntQuery("limit", options.getLimit()));
 
-        int since = getIntQuery("since", 0);
+        long since = getLongQuery("since", 0L);
         timeoutLastSeqence = since;
 
         String filterName = getQuery("filter");
@@ -1798,6 +1835,14 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                     timeoutLastSeqence = rev.getSequence();
                 }
             }
+
+            // set following parameters to call Database.changesSince(...) in changed(...) callback
+            // to fill the gap between changesSince() and changed() callbacks.
+            // https://github.com/couchbase/couchbase-lite-java-core/issues/1495
+            filled = false;
+            changesOptions = options;
+            changesSince = since;
+
             db.addChangeListener(this);
 
             //timeout
@@ -1895,7 +1940,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                         OutputStream os = connection.getResponseOutputStream();
                         if (os != null) {
                             if (longpoll)
-                                sendLongpollChanges(null, timeoutLastSeqence);
+                                sendLongpollChanges(null, timeoutLastSeqence, null);
                             else
                                 sendContinuousChangeLastSequenceAndFinish(timeoutLastSeqence);
                         }


### PR DESCRIPTION
- About issue #1495, In race condition, there is possibility database change event is fired between `changesSince()` method and starting to observe DatabaseChange event. For this issue, CBL Java takes solution from .NET implementation. In the first DatabaseChange event, calling `changesSince()` method.
- make consistent since variable/parameter should be long (not int)
- Added some null check
- Removed `sendLongpollChanges(List<RevisionInternal> revs)` method which allows to send response since value is `0`.
- In case of sending response from DatabaseChange event, it ignores `ChangeOptions.isIncludeConflict` parameter.
- In case of sending response from DatabaseChange event with feed=long but revs.size() is 0, should start timeout. Otherwise, I am not sure how _changes API behave.