### PR TITLE
Fixed couchbase lite p2p attachment replication on android (android i…

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -240,7 +240,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         // check if content-type is `application/json`
         String contentType = getRequestHeaderContentType();
         if (contentType != null && !contentType.equals(CONTENT_TYPE_JSON))
-            throw new CouchbaseLiteException(Status.NOT_ACCEPTABLE);
+            throw new CouchbaseLiteException(Status.UNSUPPORTED_TYPE);
 
         // parse body text
         InputStream contentStream = connection.getRequestInputStream();


### PR DESCRIPTION
…ssue 1037)

original ticket: https://github.com/couchbase/couchbase-lite-android/issues/1037

There are two reasons that makes p2p attachment replication fails.
1. Router can not handle multi-part requests
2. Push replicator does not execute fall-back solution (push by JSON) because Router returns http error 406 instead of 415.

In this commit, fix case 2. Case 1 I will create new ticket.