### PR TITLE
Fixed #1539 - ConnectionError: ('Connection aborted.', error(54, 'Connection reset by peer'))

### DIFF
--- a/src/main/java/com/couchbase/lite/Database.java
+++ b/src/main/java/com/couchbase/lite/Database.java
@@ -809,6 +809,13 @@ public class Database implements StoreDelegate {
      */
     @InterfaceAudience.Private
     public void databaseStorageChanged(DocumentChange change) {
+
+        // reduce memory usage by releasing body.object, body.json remains.
+        if (change != null &&
+                change.getAddedRevision() != null &&
+                change.getAddedRevision().getBody() != null)
+            change.getAddedRevision().getBody().compact();
+
         if (change.getRevisionId() != null)
             Log.v(Log.TAG, "---> Added: %s as seq %d",
                     change.getAddedRevision(), change.getAddedRevision().getSequence());


### PR DESCRIPTION
By calling `Body.compact()` reduces the memory usage per change.