### PR TITLE
Fixed #911 - Multiple duplicate replication change events sent in pul…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -93,6 +93,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     private static ReplicationStateTransition TRANS_IDLE_TO_RUNNING =
             new ReplicationStateTransition(ReplicationState.IDLE,
                     ReplicationState.RUNNING, ReplicationTrigger.RESUME);
+    private static ReplicationStateTransition TRANS_RUNNING_TO_STOPPING =
+            new ReplicationStateTransition(ReplicationState.RUNNING,
+                    ReplicationState.STOPPING, ReplicationTrigger.STOP_GRACEFUL);
 
     // Change listeners can be called back synchronously or asynchronously.
     protected enum ChangeListenerNotifyStyle {
@@ -1501,6 +1504,12 @@ abstract class ReplicationInternal implements BlockingQueueListener {
         if ((TRANS_RUNNING_TO_IDLE.equals(replStateTrans)
                 || TRANS_IDLE_TO_RUNNING.equals(replStateTrans)) && authenticating) {
             Log.i(TAG, "During middle of authentication, not notify Replicator state change");
+            return;
+        }
+
+        // ignore RUNNING -> STOPPING as both are ACTIVE
+        if (TRANS_RUNNING_TO_STOPPING.equals(replStateTrans)) {
+            Log.v(TAG, "Both RUNNING and STOPPING are ACTIVE, not notify  Replicator state change");
             return;
         }
 


### PR DESCRIPTION
…l replication

Multiple reasons might cause this problem:
- CBL Java/Android threading model is different. When notification is sent and when notification was delivered, Replication state might be changed. To avoid the problem from this behavior, need to access ChangeEvent variables instead of Replicator variables.
Instead of
```
Replicator pull;
Log.e(TAG, pull.getCompletedChangesCount() + " / " + pull.getChangesCount() + " [status = " + pull.getStatus() + "]");
```
should be
```
ChangeEvent event;
Log.e(TAG, event.getCompletedChangesCount() + " / " + event.getChangesCount() + " [status = " + event.getStatus() + "]");
```
- `Replicator.ChangeEvent` does not have `ReplicationStatus getStatus()`. Added method. `ReplicationStatus status;` is `final` variable. So it should not be changed.
- Public replicator Status and CBL Java/Android internal replicator status is not exactly same.  Internal status has more detailed states. So few status match to one public replicator state. In case public replicator state is not changed, not notify changes.