### PR TITLE
Fixed #1533 - Document.update() silently swallows CouchbaseLiteException

### DIFF
--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -361,7 +361,7 @@ public class Document {
      * @param updater the callback DocumentUpdater implementation.  Will be called on each
      *                attempt to save. Should update the given revision's properties and then
      *                return YES, or just return NO to cancel.
-     * @return The new saved revision, or null on error or cancellation.
+     * @return The new saved revision, or null on cancellation.
      * @throws CouchbaseLiteException
      */
     @InterfaceAudience.Public
@@ -383,8 +383,9 @@ public class Document {
                 }
             } catch (CouchbaseLiteException e) {
                 lastErrorCode = e.getCBLStatus().getCode();
+                if (lastErrorCode != Status.CONFLICT)
+                    throw e;
             }
-
         } while (lastErrorCode == Status.CONFLICT);
         return null;
     }


### PR DESCRIPTION
https://github.com/couchbase/couchbase-lite-java-core/issues/1533

- In case of not conflicting, not throwing exception is bug.

iOS implementation as reference
```objective-c
- (CBLSavedRevision*) update: (BOOL(^)(CBLUnsavedRevision*))block error: (NSError**)outError {
    NSError* error;
    do {
        // if there is a conflict error, get the latest revision from db instead of cache
        if (error)
            [self forgetCurrentRevision];
        CBLUnsavedRevision* newRev = self.newRevision;
        if (!block(newRev)) {
            error = nil;
            break; // cancel
        }
        CBLSavedRevision* savedRev = [newRev save: &error];
        if (savedRev)
            return savedRev; // success
    } while (CBLStatusFromNSError(error, 500) == kCBLStatusConflict);
    if (outError)
        *outError = error;
    return nil;
}
```