### PR TITLE
Fixed Android Issue 1059 - setAuthenticator() does not set login para…

### DIFF
--- a/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
+++ b/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
@@ -184,7 +184,8 @@ public class CouchbaseLiteHttpClientFactory implements HttpClientFactory {
             }
 
             public X509Certificate[] getAcceptedIssuers() {
-                return null;
+                // https://github.com/square/okhttp/issues/2329#issuecomment-188325043
+                return new X509Certificate[0];
             }
         };
         SSLContext sslContext = SSLContext.getInstance("TLS");


### PR DESCRIPTION
…meters

Issue is not in basic authentication. Problem is in the code allows self-signed certificate. From OkHttp v3, `setAuthenticator()` should return empty array instead of `null`.