### PR TITLE
Fixed #1558 - Listener returning different error codes for negative t…

### DIFF
--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -241,7 +241,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         // check if content-type is `application/json`
         String contentType = getRequestHeaderContentType();
         if (contentType != null && !contentType.equals(CONTENT_TYPE_JSON))
-            throw new CouchbaseLiteException(Status.UNSUPPORTED_TYPE);
+            throw new CouchbaseLiteException(Status.NOT_ACCEPTABLE);
 
         // parse body text
         InputStream contentStream = connection.getRequestInputStream();


### PR DESCRIPTION
…ests 1.3.1 vs 1.4

- Functional test expects 406 instead of 415 in case content-type is not acceptable. Also CBL iOS returns 406.