### PR TITLE
Pull replicator performance improvement

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -75,6 +75,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     public static final int MAX_PENDING_DOCS = 200;
 
     private static final int INSERTION_BATCHER_DELAY = 250; // 0.25 Seconds
+    private static final int INSERTION_BATCHER_CAPACITY = 100;
 
     private ChangeTracker changeTracker;
     protected SequenceMap pendingSequences;
@@ -119,9 +120,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
 
     private void initDownloadsToInsert() {
         if (downloadsToInsert == null) {
-            int capacity = 200;
             downloadsToInsert = new Batcher<RevisionInternal>(executor,
-                    capacity, INSERTION_BATCHER_DELAY, new BatchProcessor<RevisionInternal>() {
+                    INSERTION_BATCHER_CAPACITY, INSERTION_BATCHER_DELAY, new BatchProcessor<RevisionInternal>() {
                 @Override
                 public void process(List<RevisionInternal> inbox) {
                     insertDownloads(inbox);

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -114,7 +114,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected Map<String, Object> requestHeaders;
     private String serverType;
     protected Batcher<RevisionInternal> batcher;
-    protected static int PROCESSOR_DELAY = 500;
+    protected static int PROCESSOR_DELAY = 250; // 0.25 Seconds
     protected static int INBOX_CAPACITY = 100;
     protected ScheduledExecutorService remoteRequestExecutor;
     private Throwable error; // use private to make sure if error is set through setError()


### PR DESCRIPTION
Original Ticket: https://github.com/couchbase/couchbase-lite-android/issues/1030

- large batch size for download-to-insert could require more memory. Changing it from 200 to 100, it could reduce peak memory usage.
- 0.5 sec could be too long to wait batcher is filled. changed it to 0.25 sec.