### PR TITLE
Fixed #1564 - P2P sanity test failing

### DIFF
--- a/src/main/java/com/couchbase/lite/Manager.java
+++ b/src/main/java/com/couchbase/lite/Manager.java
@@ -24,6 +24,7 @@ import com.couchbase.lite.support.Version;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.StreamUtils;
 import com.couchbase.lite.util.Utils;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
@@ -69,7 +70,10 @@ public final class Manager {
     public static final String FORESTDB_STORAGE = "ForestDB";
 
     // NOTE: Jackson is thread-safe http://wiki.fasterxml.com/JacksonFAQThreadSafety
-    private static final ObjectMapper mapper = new ObjectMapper();
+    // NOTE: Jackson automatically close input resource after parsing the conent.
+    //       Need to disable it. https://github.com/FasterXML/jackson-databind/issues/697
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
 
     private ManagerOptions options;
     private File directoryFile;

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -244,6 +244,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
             throw new CouchbaseLiteException(Status.NOT_ACCEPTABLE);
 
         // parse body text
+        // NOTE: contentStream should not be close immediately. It will close Socket connection.
         InputStream contentStream = connection.getRequestInputStream();
         try {
             return Manager.getObjectMapper().readValue(contentStream, Map.class);


### PR DESCRIPTION
# Notes
- Jackson automatically closes InputStream after parsing the content. It means Jackson calls InputStream.close()
- TJWS InputStream implementation closes connection if Keep-alive=false (connection: close)

# Solution
- Disable  auto closing of Jackson by disabling `JsonParser.Feature.AUTO_CLOSE_SOURCE`