### PR TITLE
Fixed #1563 - Database deletion failing with 1.4-25

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -878,17 +878,7 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                         Map<String, Object> response = (Map<String, Object>) result;
                         body.put("_rev", response.get("rev"));
                         remoteCheckpoint = body;
-                        boolean isOpen = false;
-                        try {
-                            if (db != null) {
-                                db.open();
-                                isOpen = true;
-                            }
-                        } catch (CouchbaseLiteException ex) {
-                            Log.w(Log.TAG_SYNC, "%s: Cannot open the database", ex, this);
-                        }
-
-                        if (isOpen) {
+                        if (db != null && db.isOpen()) {
                             Log.d(Log.TAG_SYNC,
                                     "%s: saved remote checkpoint, updating local checkpoint. RemoteCheckpoint: %s",
                                     this, remoteCheckpoint);

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -622,6 +622,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
                 connection.getResponseBody() == null &&
                 connection.getHeaderField("Content-Type") == null &&
                 dontOverwriteBody == false) {
+                connection.getResHeader().add("Content-Type", CONTENT_TYPE_JSON);
                 connection.setResponseBody(new Body("{\"ok\":true}".getBytes()));
             }
 
@@ -1141,13 +1142,17 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
         return new Status(Status.CREATED);
     }
 
-    public Status do_DELETE_Database(Database _db, String _docID, String _attachmentName)
-            throws CouchbaseLiteException {
+    public Status do_DELETE_Database(Database _db, String _docID, String _attachmentName) {
         if (getQuery("rev") != null) {
             return new Status(Status.BAD_REQUEST);
             // CouchDB checks for this; probably meant to be a document deletion
         }
-        db.delete();
+        try {
+            db.delete();
+        } catch (CouchbaseLiteException e) {
+            Log.w(TAG, "Failed to delete database: do_DELETE_Database()", e);
+            return e.getCBLStatus();
+        }
         return new Status(Status.OK);
     }
 


### PR DESCRIPTION
### Router.java
- The default response for REST API does not set `Content-Type` header
- do_DELETE_Database() throws Exception. It causes method invocation error which misleads the debugging.

### ReplicationInternal.java
- Calling `Database.open()` in `saveLastSequence()` could causes deadlock with `Database` instance

### Database.java
- synchronized(Database): open()/delete()/close()/exists() - to avoid concurrent access to database file, and also avoiding concurrently executed open() and delete() or open() and close()
- synchronized(Manager.lockDatabases) - to avoid returning Database intense, which is middle of deletion, from Manager

### Manager.java
- Introduce `lockDatabases` lock object to protect `databases` Map instance. It prevents the threads obtain invalid Database instance such as deleting database.