### PR TITLE
Fixed #1569 - Out Of MemoryError on replication

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/Body.java
+++ b/src/main/java/com/couchbase/lite/internal/Body.java
@@ -31,6 +31,7 @@ import java.util.Map;
  */
 public class Body {
     private byte[] json;
+    private long size = 0;
     private Object object;
 
     public Body(byte[] json) {
@@ -39,6 +40,16 @@ public class Body {
 
     public Body(Map<String, Object> properties) {
         this.object = properties;
+    }
+
+    public Body(byte[] json, long size) {
+        this.json = json;
+        this.size = size;
+    }
+
+    public Body(Map<String, Object> properties, long size) {
+        this.object = properties;
+        this.size = size;
     }
 
     public Body(List<?> array) {
@@ -170,5 +181,9 @@ public class Body {
 
     public Object getObject(String key) {
         return getProperties() != null ? getProperties().get(key) : null;
+    }
+
+    public long getSize() {
+        return size;
     }
 }

--- a/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
+++ b/src/main/java/com/couchbase/lite/internal/RevisionInternal.java
@@ -64,6 +64,10 @@ public class RevisionInternal {
         this(new Body(properties));
     }
 
+    public RevisionInternal(Map<String, Object> properties, long size) {
+        this(new Body(properties, size));
+    }
+
     ////////////////////////////////////////////////////////////
     // Setter / Getter methods
     ////////////////////////////////////////////////////////////

--- a/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
+++ b/src/main/java/com/couchbase/lite/replicator/PulledRevision.java
@@ -40,6 +40,10 @@ class PulledRevision extends RevisionInternal {
         super(properties);
     }
 
+    public PulledRevision(Map<String, Object> properties, long size) {
+        super(properties, size);
+    }
+
     public String getRemoteSequenceID() {
         return remoteSequenceID;
     }

--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -47,6 +47,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
@@ -77,6 +78,8 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
     private static final int INSERTION_BATCHER_DELAY = 250; // 0.25 Seconds
     private static final int INSERTION_BATCHER_CAPACITY = 100;
 
+    private static final long MAX_QUEUE_MEMORY_SIZE = 2 * 1024 * 1024; // 2MB
+
     private ChangeTracker changeTracker;
     protected SequenceMap pendingSequences;
     protected Boolean canBulkGet;  // Does the server support _bulk_get requests?
@@ -88,6 +91,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             new ArrayList<RevisionInternal>(100));
     protected int httpConnectionCount;
     protected Batcher<RevisionInternal> downloadsToInsert;
+    protected AtomicLong queuedMemorySize = new AtomicLong(0);
 
     private String str = null;
 
@@ -125,6 +129,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                 @Override
                 public void process(List<RevisionInternal> inbox) {
                     insertDownloads(inbox);
+                    if (downloadsToInsert.count() == 0) {
+                        queuedMemorySize.set(0);
+                    }
                 }
             });
         }
@@ -332,12 +339,12 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                     db,
                     this.requestHeaders,
                     new RemoteBulkDownloaderRequest.BulkDownloaderDocument() {
-                        public void onDocument(Map<String, Object> props) {
+                        public void onDocument(Map<String, Object> props, long size) {
                             // Got a revision!
                             // Find the matching revision in 'remainingRevs' and get its sequence:
                             RevisionInternal rev;
                             if (props.get("_id") != null) {
-                                rev = new RevisionInternal(props);
+                                rev = new RevisionInternal(props, size);
                             } else {
                                 rev = new RevisionInternal((String) props.get("id"),
                                         (String) props.get("rev"), false);
@@ -456,12 +463,22 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
             }
         }
 
-        if (rev != null && rev.getBody() != null)
-            rev.getBody().compact();
+        // NOTE: should not/not necessary to call Body.compact()
+        // new RevisionInternal(Map<string, Object>) creates Body instance only
+        // with `object`. Serializing object to json causes two unnecessary
+        // JSON serializations.
+
+        if (rev.getBody() != null)
+            queuedMemorySize.addAndGet(rev.getBody().getSize());
 
         downloadsToInsert.queueObject(rev);
-    }
 
+        // if queue memory size is more than maximum, force flush the queue.
+        if (queuedMemorySize.get() > MAX_QUEUE_MEMORY_SIZE) {
+            Log.d(TAG, "Flushing queued memory size at: " + queuedMemorySize);
+            downloadsToInsert.flushAll(true);
+        }
+    }
 
     // Get as many revisions as possible in one _all_docs request.
     // This is compatible with CouchDB, but it only works for revs of generation 1 without attachments.
@@ -586,7 +603,9 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                                 continue;
                             }
                         }
-                        if (rev.getBody() != null) rev.getBody().compact();
+
+                        // NOTE: calling Body.compact() here cause another JSON serialization by Jackson.
+                        //       At this point Body.json is null, and Body.object has values.
 
                         // Mark this revision's fake sequence as processed:
                         pendingSequences.removeSequence(fakeSequence);
@@ -700,18 +719,33 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                                 setError(e);
                             }
                         } else {
+
                             Map<String, Object> properties = (Map<String, Object>) result;
-                            PulledRevision gotRev = new PulledRevision(properties);
+                            long size = 0;
+                            if (httpResponse != null && httpResponse.body() != null)
+                                size = httpResponse.body().contentLength();
+                            PulledRevision gotRev = new PulledRevision(properties, size);
                             gotRev.setSequence(rev.getSequence());
 
                             Log.d(TAG, "%s: pullRemoteRevision add rev: %s to batcher: %s",
                                     PullerInternal.this, gotRev, downloadsToInsert);
 
+                            // NOTE: should not/not necessary to call Body.compact()
+                            // new PulledRevision(Map<string, Object>) creates Body instance only
+                            // with `object`. Serializing object to json causes two unnecessary
+                            // JSON serializations.
+
                             if (gotRev.getBody() != null)
-                                gotRev.getBody().compact();
+                                queuedMemorySize.addAndGet(gotRev.getBody().getSize());
 
                             // Add to batcher ... eventually it will be fed to -insertRevisions:.
                             downloadsToInsert.queueObject(gotRev);
+
+                            // if queue memory size is more than maximum, force flush the queue.
+                            if (queuedMemorySize.get() > MAX_QUEUE_MEMORY_SIZE) {
+                                Log.d(TAG, "Flushing  queued memory size at: " + queuedMemorySize);
+                                downloadsToInsert.flushAll(true);
+                            }
                         }
 
                         // Note that we've finished this task:

--- a/src/main/java/com/couchbase/lite/replicator/RemoteBulkDownloaderRequest.java
+++ b/src/main/java/com/couchbase/lite/replicator/RemoteBulkDownloaderRequest.java
@@ -49,7 +49,7 @@ public class RemoteBulkDownloaderRequest extends RemoteRequest implements Multip
 
     @InterfaceAudience.Private
     public interface BulkDownloaderDocument {
-        void onDocument(Map<String, Object> props);
+        void onDocument(Map<String, Object> props, long size);
     }
 
     ////////////////////////////////////////////////////////////
@@ -226,7 +226,7 @@ public class RemoteBulkDownloaderRequest extends RemoteRequest implements Multip
         if (_docReader == null)
             throw new IllegalStateException("_docReader is not defined");
         _docReader.finish();
-        _onDocument.onDocument(_docReader.getDocumentProperties());
+        _onDocument.onDocument(_docReader.getDocumentProperties(), _docReader.getDocumentSize());
         _docReader = null;
         Log.v(TAG, "%s: Finished document", this);
     }

--- a/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
+++ b/src/main/java/com/couchbase/lite/support/MultipartDocumentReader.java
@@ -33,6 +33,7 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
     private CustomByteArrayOutputStream jsonBuffer;
     private boolean jsonCompressed;
     private Map<String, Object> document;
+    private long documentSize = 0; // original JSON document size
     private Database database;
     private Map<String, BlobStoreWriter> attachmentsByName;
     private Map<String, BlobStoreWriter> attachmentsByMd5Digest;
@@ -45,7 +46,14 @@ public class MultipartDocumentReader implements MultipartReaderDelegate {
         return document;
     }
 
+    public long getDocumentSize() {
+        return documentSize;
+    }
+
     public void parseJsonBuffer() {
+
+        documentSize = jsonBuffer.count();
+
         ByteArrayInputStream in = new ByteArrayInputStream(jsonBuffer.buf(), 0, jsonBuffer.count());
         try {
             try {


### PR DESCRIPTION
### Problems
- `downloadsToInsert` queue (Batcher) will holds 100 RevisionInternal instances. In case each document size is large, it consumes a lot of memory, and it causes OOM.
- Each pull replication steps cause unnecessary JSON serialization/deserialization. If document size is large, OOM is caused by JSON serialization/deserialization

### Solution
- No longer calls Body.compact() method in [PullerInternal](
https://github.com/couchbase/couchbase-lite-java-core/compare/issue/1569?expand=1#diff-c739f8c5636953997d2d00324944fc7fL460). By eliminate this line, byte[] -> Object -> byte[] between download data from the server and insert a document into the database.
- Set maximum size (2MB) of `downloadsToInsert` queue. Once reach the maximum, force flush the downloadsToInsert queue.
- `queuedMemorySize` is a critial section, but it is hard to maintain its value accurately. So it is declared as AtomicLong, but not be synchronized with the downloadsToInsert queue.
- All other changes are to maintain content (JSON) size. By this change, it does not require to serialize the object to JSON string.


