### PR TITLE
Fixed #1581 - Replication failures when running Sync Gateway in distr…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PullerInternal.java
@@ -476,7 +476,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
         // if queue memory size is more than maximum, force flush the queue.
         if (queuedMemorySize.get() > MAX_QUEUE_MEMORY_SIZE) {
             Log.d(TAG, "Flushing queued memory size at: " + queuedMemorySize);
-            downloadsToInsert.flushAll(true);
+            downloadsToInsert.flushAllAndWait();
         }
     }
 
@@ -744,7 +744,7 @@ public class PullerInternal extends ReplicationInternal implements ChangeTracker
                             // if queue memory size is more than maximum, force flush the queue.
                             if (queuedMemorySize.get() > MAX_QUEUE_MEMORY_SIZE) {
                                 Log.d(TAG, "Flushing  queued memory size at: " + queuedMemorySize);
-                                downloadsToInsert.flushAll(true);
+                                downloadsToInsert.flushAllAndWait();
                             }
                         }
 

--- a/src/main/java/com/couchbase/lite/support/Batcher.java
+++ b/src/main/java/com/couchbase/lite/support/Batcher.java
@@ -53,6 +53,7 @@ public class Batcher<T> {
 
     private final Object mutex = new Object();
     private final Object processMutex = new Object();
+    private final Object flushAllMutext = new Object();
 
     ///////////////////////////////////////////////////////////////////////////
     // Constructors
@@ -158,6 +159,12 @@ public class Batcher<T> {
                     processMutex.wait(5);
                 } catch (InterruptedException e) { }
             }
+        }
+    }
+
+    public void flushAllAndWait() {
+        synchronized (flushAllMutext) {
+            flushAll(true);
         }
     }
 


### PR DESCRIPTION
…ibuted index

Calling `Batcher.flushAll(true)` concurrently causes dead-lock. Need to avoid it.