### PR TITLE
Fixed #1589 - Investigate possible push replication issue

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/PusherInternal.java
@@ -749,7 +749,7 @@ public class PusherInternal extends ReplicationInternal implements Database.Chan
                     // Skip revisions that originally came from the database I'm syncing to:
                     URL source = change.getSource();
                     if (source != null && source.toURI().equals(remoteUri))
-                        return;
+                        continue;
                     RevisionInternal rev = change.getAddedRevision();
                     if (rev == null)
                         continue;


### PR DESCRIPTION
- DatabaseChanges notification could be sent with mixed documents that are from local and remote. `submitRevisions()` method returns from the method once it found document from remote. It makes locally created document skipped.