### PR TITLE
Fixed #1627 - Replicator does not close a connection immediately afte…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -335,8 +335,10 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                     Replication.DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN);
         }
 
-        // Close and remove all idle connections in the pool.
-        clientFactory.evictAllConnectionsInPool();
+        // Close and remove all idle connections in the pool,
+        // if HttpClientFactory is per a replicator.
+        if (db.getManager().getDefaultHttpClientFactory() == null)
+            clientFactory.evictAllConnectionsInPool();
     }
 
     protected void initAuthorizer() {

--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -334,6 +334,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                     Replication.DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN,
                     Replication.DEFAULT_MAX_TIMEOUT_FOR_SHUTDOWN);
         }
+
+        // Close and remove all idle connections in the pool.
+        clientFactory.evictAllConnectionsInPool();
     }
 
     protected void initAuthorizer() {

--- a/src/main/java/com/couchbase/lite/replicator/RequestUtils.java
+++ b/src/main/java/com/couchbase/lite/replicator/RequestUtils.java
@@ -74,6 +74,8 @@ public class RequestUtils {
             ResponseBody body = response.body();
             if (body != null)
                 body.close();
+            else
+                response.close();
         }
     }
 }

--- a/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
+++ b/src/main/java/com/couchbase/lite/support/CouchbaseLiteHttpClientFactory.java
@@ -30,6 +30,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import okhttp3.ConnectionPool;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
 import okhttp3.HttpUrl;
@@ -81,6 +82,16 @@ public class CouchbaseLiteHttpClientFactory implements HttpClientFactory {
     ////////////////////////////////////////////////////////////
     // Implementations of HttpClientFactory
     ////////////////////////////////////////////////////////////
+
+    @Override
+    @InterfaceAudience.Private
+    public void evictAllConnectionsInPool() {
+        if (client != null) {
+            ConnectionPool pool = client.connectionPool();
+            if (pool != null)
+                pool.evictAll();
+        }
+    }
 
     @Override
     @InterfaceAudience.Private

--- a/src/main/java/com/couchbase/lite/support/HttpClientFactory.java
+++ b/src/main/java/com/couchbase/lite/support/HttpClientFactory.java
@@ -32,4 +32,6 @@ public interface HttpClientFactory {
     void resetCookieStore();
 
     CookieJar getCookieStore();
+
+    void evictAllConnectionsInPool();
 }


### PR DESCRIPTION
…r stopping the replication.

Evicts all connections as soon as replicator stopped.

NOTE: However, closed connection could remain with WAIT-TIME state for a while.