### PR TITLE
Fixed #1637 - 1.x: RejectedExecutionException is through from Replicator

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -228,22 +228,20 @@ abstract class ReplicationInternal implements BlockingQueueListener {
     protected void fireTrigger(final ReplicationTrigger trigger) {
         Log.d(Log.TAG_SYNC, "%s [fireTrigger()] => " + trigger, this);
         // All state machine triggers need to happen on the replicator thread
-        if (executor != null) {
-            synchronized (executor) {
-                if (!executor.isShutdown()) {
-                    executor.submit(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                Log.d(Log.TAG_SYNC, "firing trigger: %s", trigger);
-                                stateMachine.fire(trigger);
-                            } catch (Exception e) {
-                                Log.i(Log.TAG_SYNC, "Error in StateMachine.fire(trigger): %s", e.getMessage());
-                                throw new RuntimeException(e);
-                            }
+        synchronized (executor) {
+            if (!executor.isShutdown()) {
+                executor.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            Log.d(Log.TAG_SYNC, "firing trigger: %s", trigger);
+                            stateMachine.fire(trigger);
+                        } catch (Exception e) {
+                            Log.i(Log.TAG_SYNC, "Error in StateMachine.fire(trigger): %s", e.getMessage());
+                            throw new RuntimeException(e);
                         }
-                    });
-                }
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
- `Executor.submit(...)` throws `RejectedExecutionException` if `Executor` is shutdown. So we had two choices. One is apply `try-catch` block for all Executor.submit(...) method. Another one is make Executor.submit(...), schedule(...), shutdown(), etc methods are thread safe. I picked second choice because already CBL codes has tried to be thread-safe with Executor services.