### PR TITLE
Fixed #1652 - 1.x - LiveQuery: row.getDocument().getProperties() retu…

### DIFF
--- a/src/main/java/com/couchbase/lite/QueryRow.java
+++ b/src/main/java/com/couchbase/lite/QueryRow.java
@@ -177,12 +177,16 @@ public class QueryRow {
         if (documentRevision != null)
             rev = documentRevision.getRevID();
         if (rev == null) {
-            if (value instanceof Map) {
+            if (value != null && value instanceof Map) {
                 Map<String, Object> mapValue = (Map<String, Object>) value;
                 rev = (String) mapValue.get("_rev");
-                if (rev == null) {
+                if (rev == null)
                     rev = (String) mapValue.get("rev");
-                }
+            }
+            if (rev == null && sequence >= 0) {
+                documentRevision = database.getStore().getDocument(getDocumentId(), sequence);
+                if (documentRevision != null)
+                    rev = documentRevision.getRevID();
             }
         }
         return rev;

--- a/src/main/java/com/couchbase/lite/store/SQLiteStore.java
+++ b/src/main/java/com/couchbase/lite/store/SQLiteStore.java
@@ -2745,7 +2745,7 @@ public class SQLiteStore implements Store, EncryptableStore {
     /**
      * Loads revision given its sequence. Assumes the given docID is valid.
      */
-    protected RevisionInternal getDocument(String docID, long sequence) {
+    public RevisionInternal getDocument(String docID, long sequence) {
         // Now get its revID and deletion status:
         RevisionInternal rev = null;
 

--- a/src/main/java/com/couchbase/lite/store/Store.java
+++ b/src/main/java/com/couchbase/lite/store/Store.java
@@ -372,4 +372,7 @@ public interface Store {
      */
     RevisionInternal putLocalRevision(RevisionInternal revision, String prevRevID, boolean obeyMVCC)
             throws CouchbaseLiteException;
+
+
+    RevisionInternal getDocument(String docID, long sequence);
 }


### PR DESCRIPTION
…rn null if document is deleted during indexing

- Load documentRevision of QueryRow with docID and sequence if revID is unknown when getDocumentRevisionID() method is called.