### PR TITLE
Fixed #1623 - (Potential Issue) Push replication becomes slower as l…

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -275,6 +275,9 @@ abstract class ReplicationInternal implements BlockingQueueListener {
             initAuthorizer();
             // initialize request workers
             initializeRequestWorkers();
+            // reset lastSequence
+            // https://github.com/couchbase/couchbase-lite-java-core/issues/1623
+            this.lastSequence = null;
             // single-shot replication
             if (!isContinuous())
                 goOnline();


### PR DESCRIPTION
…ocal DB grows

Reviewed https://github.com/couchbase/couchbase-lite-net/commit/54237fed0f66cc959d162740b7df3e664cad387b
CBL Android already has code to remove  revision from pending. Therefore, only adapt lastSequence initialization in `ReplicationInternal.start()` method