### PR TITLE
Fixed #290 - 1.x: [Memory] Memory leak in allReplicators

### DIFF
--- a/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
+++ b/src/main/java/com/couchbase/lite/replicator/ReplicationInternal.java
@@ -265,7 +265,6 @@ abstract class ReplicationInternal implements BlockingQueueListener {
                 fireTrigger(ReplicationTrigger.STOP_IMMEDIATE);
                 return;
             }
-            db.addReplication(parentReplication);
             db.addActiveReplication(parentReplication);
             this.authenticating = false;
             initSessionId();

--- a/src/main/java/com/couchbase/lite/router/Router.java
+++ b/src/main/java/com/couchbase/lite/router/Router.java
@@ -970,7 +970,7 @@ public class Router implements Database.ChangeListener, Database.DatabaseListene
 
         List<Map<String, Object>> activities = new ArrayList<Map<String, Object>>();
         for (Database db : manager.allOpenDatabases()) {
-            List<Replication> activeReplicators = db.getActiveReplications();
+            List<Replication> activeReplicators = db.getAllReplications();
             if (activeReplicators != null) {
                 for (Replication replicator : activeReplicators) {
                     if (replicator.isRunning()) {


### PR DESCRIPTION
Problems:
- `allReplicators` container holds all `Replicator` instances which includes `STOPPED` state replicators. This keep holding a lot of memory if the application creates many one-shot replicators.

Changes:
- Eliminated allReplicators container.
- Renamed `getActiveReplicaotrs()` to `getAllReplicators()` which is public API.